### PR TITLE
feat(zmq): add subscriber example, dedicated metrics, and Docker feature build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: Docker Images
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ 'v*' ]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+
+      - name: Build and push (default)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push (zmq)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            ENABLE_ZMQ_SINK=1
+          tags: |
+            ghcr.io/${{ github.repository }}:zmq
+            ghcr.io/${{ github.repository }}:latest-zmq
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.idea/polygon-rs.iml
+++ b/.idea/polygon-rs.iml
@@ -2,6 +2,7 @@
 <module type="CPP_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/examples" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0.145"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 flate2 = "1.0"
-hostname = "0.3"
+hostname = "0.4.1"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 flate2 = "1.0"
 hostname = "0.4.1"
+smallvec = "1.13"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,16 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.47.1", features = ["full"] }
+tokio = { version = "1.47", features = ["full"] }
 tokio-tungstenite = { version = "0.28", features = ["native-tls"] }
-futures = "0.3.31"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
+futures = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 flate2 = "1.0"
-hostname = "0.4.1"
-smallvec = "1.13"
+hostname = "0.4"
+smallvec = "1.15"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,12 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 flate2 = "1.0"
 hostname = "0.3"
+
+[features]
+default = []
+# Enable ZeroMQ sink support (requires libzmq on the system)
+zmq-sink = ["zmq"]
+
+[dependencies.zmq]
+version = "0.10"
+optional = true

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ ZMQ PUB sink
 
 Docker with ZMQ feature
 - Build with ZeroMQ enabled: `docker build --build-arg ENABLE_ZMQ_SINK=1 -t polygon-rs:zmq .`
+ - Image tags when using GHCR CI:
+   - Default: `ghcr.io/OWNER/REPO:latest`
+   - ZMQ-enabled: `ghcr.io/OWNER/REPO:zmq` and `ghcr.io/OWNER/REPO:latest-zmq`
+ - Local convenience tag added: `polygon-rs:latest-zmq`
 
 ## Effective Config
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ High‑performance streamer for Polygon.io clusters (stocks, futures, options, c
 | `METRICS_ADDR` | `127.0.0.1:9898` | Exposes `/metrics`, `/health`, `/ready` |
 | `STATS_INTERVAL_SECS` | `60` | Periodic stats log interval |
 | `BP_WARN_INTERVAL_SECS` | `5` | Backpressure warning interval |
-| `EMIT_NDJSON` | `false` | Emit NDJSON event stream |
+| `SINK` | `stdout` | One of: `stdout`, `ndjson`, `zmq` |
+| `EMIT_NDJSON` | `false` | Legacy toggle; if `SINK` unset and this is `true`, selects `ndjson` |
 | `NDJSON_DEST` | `stdout` | `stdout` or file path |
 | `NDJSON_CHANNEL_CAP` | `2048` | NDJSON pipeline channel capacity |
 | `NDJSON_WARN_INTERVAL_SECS` | `5` | NDJSON backpressure warn interval |
@@ -30,6 +31,12 @@ High‑performance streamer for Polygon.io clusters (stocks, futures, options, c
 | `NDJSON_INCLUDE` | none | Comma patterns (e.g., `T:ES*,Q:ES*`) |
 | `NDJSON_SAMPLE_QUOTES` | `1` | Emit 1 in N quotes |
 | `NDJSON_SPLIT_PER_TYPE` | `false` | Split NDJSON files by type |
+| `ZMQ_ENDPOINT` | `tcp://127.0.0.1:5556` | ZMQ PUB endpoint (connect or bind) |
+| `ZMQ_BIND` | `false` | When `true`, bind instead of connect |
+| `ZMQ_CHANNEL_CAP` | `4096` | Internal channel capacity for ZMQ sink |
+| `ZMQ_WARN_INTERVAL_SECS` | `5` | Backpressure warn interval for ZMQ |
+| `ZMQ_SND_HWM` | unset | Optional zmq `SNDHWM` (messages) |
+| `ZMQ_TOPIC_PREFIX` | empty | Optional topic prefix for PUB topic |
 | `READY_MIN_MESSAGES` | `1` | Messages required before `/ready` returns READY |
 | `READY_DELAY_MS` | `0` | Additional delay before READY (milliseconds) |
 
@@ -57,6 +64,11 @@ High‑performance streamer for Polygon.io clusters (stocks, futures, options, c
    git clone [repository-url]
    cd polygon-streams
    cargo build --release
+   # ZMQ sink requires libzmq and feature flag:
+   # macOS (brew):   brew install zeromq
+   # Debian/Ubuntu:  sudo apt-get install -y libzmq3-dev
+   # RHEL/CentOS:    sudo yum install -y zeromq-devel
+   # Then build with: cargo build --release --features zmq-sink
    ```
 
 ## Configuration
@@ -109,10 +121,17 @@ RUST_LOG=info cargo run --release
 ```
 
 Examples
-- Use stocks cluster with default subscription (T.*):
-  - `export POLYGON_CLUSTER=stocks && RUST_LOG=warn,polygon_events=info cargo run --release`
-- Use crypto cluster and explicit subscription:
-  - `export POLYGON_CLUSTER=crypto && export SUBSCRIPTION='T:BTC*' && RUST_LOG=warn,polygon_events=info cargo run --release`
+- Stdout sink (default) with stocks cluster:
+  - `export POLYGON_CLUSTER=stocks && SINK=stdout RUST_LOG=warn,polygon_events=info cargo run --release`
+- NDJSON to file with futures cluster:
+  - `export POLYGON_CLUSTER=futures && SINK=ndjson NDJSON_DEST=/var/log/polygon.ndjson RUST_LOG=warn cargo run --release`
+- NDJSON to stdout (pipe to jq):
+  - `SINK=ndjson NDJSON_DEST=stdout RUST_LOG=warn cargo run --release | jq -c .`
+- ZMQ PUB sink (requires feature build):
+  - `cargo run --release --features zmq-sink` with `SINK=zmq ZMQ_ENDPOINT=tcp://127.0.0.1:5556`
+  - Subscriber examples:
+    - Rust: `cargo run --release --features zmq-sink --example zmq_sub`
+    - Python: `pip install pyzmq && ZMQ_SUB_ENDPOINT=tcp://127.0.0.1:5556 python3 examples/zmq_sub.py`
 
 ## Output Format
 
@@ -135,12 +154,27 @@ Log filtering tips
   - `RUST_LOG=warn,polygon_events=info,polygon_stats=info`
 
 NDJSON stream
-- When enabled, each event is emitted as one JSON line with fields: `ingest_ts`, `type`, `symbol`, `topic`, `feed`, `ts`, `payload` (object), `hostname`, `app_version`, `schema_version`, and `seq`.
-- Example: `EMIT_NDJSON=true NDJSON_DEST=stdout RUST_LOG=warn cargo run --release | head -n1 | jq .`
+- Enable with `SINK=ndjson`.
+- Each event is emitted as one JSON line with fields: `ingest_ts`, `type`, `symbol`, `topic`, `feed`, `ts`, `payload` (object), `hostname`, `app_version`, `schema_version`, and `seq`.
+- Example: `SINK=ndjson NDJSON_DEST=stdout RUST_LOG=warn cargo run --release | head -n1 | jq .`
 
 Filtering and sampling (env only)
 - Include only specific symbols/types in NDJSON via comma-separated patterns (supports `*` suffix wildcard): `NDJSON_INCLUDE='T:ES*,Q:ES*'`
 - Sample quotes to reduce volume (emit 1 in N): `NDJSON_SAMPLE_QUOTES=10`
+
+ZMQ PUB sink
+- Build with feature: `cargo run --release --features zmq-sink`
+- Configure:
+  - `SINK=zmq`
+  - `ZMQ_ENDPOINT=tcp://127.0.0.1:5556` and optionally `ZMQ_BIND=true`
+  - Optional `ZMQ_SND_HWM` to set ZeroMQ high water mark and `ZMQ_TOPIC_PREFIX` to prefix topics.
+- Messages are sent as multipart `[topic, payload]` where:
+  - `topic` = `"T:SYMBOL"` or `"Q:SYMBOL"` (with optional `ZMQ_TOPIC_PREFIX`)
+  - `payload` = NDJSON event (same schema as file/stdout)
+ - Monitor metrics: `polygon_zmq_sent_total` (sent) and `polygon_zmq_drops_total` (dropped due to backpressure).
+
+Docker with ZMQ feature
+- Build with ZeroMQ enabled: `docker build --build-arg ENABLE_ZMQ_SINK=1 -t polygon-rs:zmq .`
 
 ## Effective Config
 

--- a/README.md
+++ b/README.md
@@ -200,10 +200,13 @@ RUST_LOG=warn,polygon_config=info cargo run --release
   - Tune `HEARTBEAT_INTERVAL_SECS` if needed.
 - Readiness never READY
   - Ensure messages are flowing (topic matches cluster). Adjust `READY_MIN_MESSAGES` / `READY_DELAY_MS`.
-- Backpressure drops (processing or NDJSON)
-  - Increase `CHANNEL_CAP` / `NDJSON_CHANNEL_CAP`, enable rotation (`NDJSON_MAX_BYTES`).
-  - Reduce volume with `NDJSON_INCLUDE` / `NDJSON_SAMPLE_QUOTES`.
-  - Watch `polygon_channel_drops_total` and `polygon_ndjson_drops_total`.
+- Backpressure drops (processing / NDJSON / ZMQ)
+  - Increase capacities: `CHANNEL_CAP`, `NDJSON_CHANNEL_CAP`, or `ZMQ_CHANNEL_CAP` (for ZMQ sink).
+  - For NDJSON, enable rotation (`NDJSON_MAX_BYTES`) and consider `NDJSON_INCLUDE` / `NDJSON_SAMPLE_QUOTES` to reduce volume.
+  - Metrics to watch:
+    - Processing drops: `polygon_channel_drops_total`
+    - NDJSON: `polygon_ndjson_drops_total`, `polygon_ndjson_written_total`
+    - ZMQ: `polygon_zmq_drops_total`, `polygon_zmq_sent_total`
 
 ## Error Handling
 
@@ -215,9 +218,11 @@ RUST_LOG=warn,polygon_config=info cargo run --release
 - Health: `curl http://127.0.0.1:9898/health` -> `200 OK` with `OK`
 - Readiness: `curl http://127.0.0.1:9898/ready` -> `200 READY` after successful subscribe (503 otherwise)
 - Metrics: `curl http://127.0.0.1:9898/metrics` (Prometheus text)
-  - Counters include `polygon_reconnects_total`, `polygon_reconnect_success_total`, `polygon_reconnect_failure_total`,
+  - Core: `polygon_build_info{...} 1`, `polygon_reconnects_total`, `polygon_reconnect_success_total`, `polygon_reconnect_failure_total`,
     `polygon_read_timeouts_total`, `polygon_heartbeats_sent_total`, `polygon_messages_received_total`,
-    `polygon_trades_total`, `polygon_quotes_total`, `polygon_errors_total`, and `polygon_build_info{...} 1`.
+    `polygon_trades_total`, `polygon_quotes_total`, `polygon_errors_total`
+  - Backpressure + sinks: `polygon_channel_drops_total`, `polygon_ndjson_drops_total`, `polygon_ndjson_written_total`,
+    `polygon_zmq_drops_total`, `polygon_zmq_sent_total`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ High‑performance streamer for Polygon.io clusters (stocks, futures, options, c
 | `STATS_INTERVAL_SECS` | `60` | Periodic stats log interval |
 | `BP_WARN_INTERVAL_SECS` | `5` | Backpressure warning interval |
 | `SINK` | `stdout` | One of: `stdout`, `ndjson`, `zmq` |
-| `EMIT_NDJSON` | `false` | Legacy toggle; if `SINK` unset and this is `true`, selects `ndjson` |
 | `NDJSON_DEST` | `stdout` | `stdout` or file path |
 | `NDJSON_CHANNEL_CAP` | `2048` | NDJSON pipeline channel capacity |
 | `NDJSON_WARN_INTERVAL_SECS` | `5` | NDJSON backpressure warn interval |
@@ -98,7 +97,6 @@ export POLYGON_API_KEY="your_api_key_here"
 # export READY_MIN_MESSAGES=1         # default: 1
 # export READY_DELAY_MS=0             # default: 0 (milliseconds)
 # NDJSON event stream (always emitted if enabled):
-# export EMIT_NDJSON=true              # default: false
 # export NDJSON_DEST=stdout            # or file path (default: stdout)
 # export NDJSON_CHANNEL_CAP=2048       # default: 2048
 # export NDJSON_WARN_INTERVAL_SECS=5   # default: 5

--- a/examples/zmq_sub.py
+++ b/examples/zmq_sub.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+Simple ZeroMQ SUB example for polygon-rs ZMQ PUB sink.
+
+Usage:
+  pip install pyzmq
+  ZMQ_SUB_ENDPOINT=tcp://127.0.0.1:5556 ZMQ_TOPIC="" python3 examples/zmq_sub.py
+
+Env:
+  ZMQ_SUB_ENDPOINT  PUB endpoint to connect to (default: tcp://127.0.0.1:5556)
+  ZMQ_TOPIC         Subscription prefix (empty = all; e.g., "T:" or "T:ES")
+"""
+
+import os
+import sys
+import zmq  # type: ignore
+
+
+def main() -> int:
+    endpoint = os.getenv("ZMQ_SUB_ENDPOINT", "tcp://127.0.0.1:5556")
+    topic = os.getenv("ZMQ_TOPIC", "").encode()
+
+    ctx = zmq.Context.instance()
+    sock = ctx.socket(zmq.SUB)
+    sock.connect(endpoint)
+    sock.setsockopt(zmq.SUBSCRIBE, topic)
+    print(f"Subscribed to {endpoint} with topic prefix {topic.decode(errors='ignore')!r}", file=sys.stderr)
+
+    try:
+        while True:
+            # Expect multipart: [topic, payload]
+            frames = sock.recv_multipart()
+            if len(frames) != 2:
+                print(f"recv {frames}")
+                continue
+            t = frames[0].decode("utf-8", errors="replace")
+            payload = frames[1].decode("utf-8", errors="replace").rstrip("\n")
+            print(f"{t} {payload}")
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        sock.close(0)
+        ctx.term()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/examples/zmq_sub.rs
+++ b/examples/zmq_sub.rs
@@ -1,0 +1,39 @@
+// Simple ZMQ subscriber example
+// Build and run:
+//   cargo run --release --features zmq-sink --example zmq_sub
+// Env:
+//   ZMQ_SUB_ENDPOINT=tcp://127.0.0.1:5556
+//   ZMQ_TOPIC="" (empty = all topics; e.g., "T:" or "T:ES" to filter)
+
+use std::env;
+
+fn main() {
+    let endpoint = env::var("ZMQ_SUB_ENDPOINT").unwrap_or_else(|_| "tcp://127.0.0.1:5556".to_string());
+    let topic = env::var("ZMQ_TOPIC").unwrap_or_else(|_| String::new());
+
+    let ctx = zmq::Context::new();
+    let sock = ctx.socket(zmq::SocketType::SUB).expect("sub socket");
+    sock.connect(&endpoint).expect("connect");
+    sock.set_subscribe(topic.as_bytes()).expect("subscribe");
+    eprintln!("Subscribed to {} with topic prefix {:?}", endpoint, topic);
+
+    loop {
+        // Multipart frames: [topic, payload]
+        match sock.recv_multipart(0) {
+            Ok(frames) => {
+                if frames.len() == 2 {
+                    let topic = String::from_utf8_lossy(&frames[0]);
+                    let payload = String::from_utf8_lossy(&frames[1]);
+                    println!("{} {}", topic, payload.trim_end());
+                } else {
+                    println!("recv {:?}", frames);
+                }
+            }
+            Err(e) => {
+                eprintln!("recv error: {}", e);
+                break;
+            }
+        }
+    }
+}
+

--- a/examples/zmq_sub.rs
+++ b/examples/zmq_sub.rs
@@ -5,35 +5,47 @@
 //   ZMQ_SUB_ENDPOINT=tcp://127.0.0.1:5556
 //   ZMQ_TOPIC="" (empty = all topics; e.g., "T:" or "T:ES" to filter)
 
-use std::env;
+#[cfg(feature = "zmq-sink")]
+mod impls {
+    use std::env;
 
-fn main() {
-    let endpoint = env::var("ZMQ_SUB_ENDPOINT").unwrap_or_else(|_| "tcp://127.0.0.1:5556".to_string());
-    let topic = env::var("ZMQ_TOPIC").unwrap_or_else(|_| String::new());
+    pub fn run() {
+        let endpoint = env::var("ZMQ_SUB_ENDPOINT").unwrap_or_else(|_| "tcp://127.0.0.1:5556".to_string());
+        let topic = env::var("ZMQ_TOPIC").unwrap_or_else(|_| String::new());
 
-    let ctx = zmq::Context::new();
-    let sock = ctx.socket(zmq::SocketType::SUB).expect("sub socket");
-    sock.connect(&endpoint).expect("connect");
-    sock.set_subscribe(topic.as_bytes()).expect("subscribe");
-    eprintln!("Subscribed to {} with topic prefix {:?}", endpoint, topic);
+        let ctx = zmq::Context::new();
+        let sock = ctx.socket(zmq::SocketType::SUB).expect("sub socket");
+        sock.connect(&endpoint).expect("connect");
+        sock.set_subscribe(topic.as_bytes()).expect("subscribe");
+        eprintln!("Subscribed to {} with topic prefix {:?}", endpoint, topic);
 
-    loop {
-        // Multipart frames: [topic, payload]
-        match sock.recv_multipart(0) {
-            Ok(frames) => {
-                if frames.len() == 2 {
-                    let topic = String::from_utf8_lossy(&frames[0]);
-                    let payload = String::from_utf8_lossy(&frames[1]);
-                    println!("{} {}", topic, payload.trim_end());
-                } else {
-                    println!("recv {:?}", frames);
+        loop {
+            // Multipart frames: [topic, payload]
+            match sock.recv_multipart(0) {
+                Ok(frames) => {
+                    if frames.len() == 2 {
+                        let topic = String::from_utf8_lossy(&frames[0]);
+                        let payload = String::from_utf8_lossy(&frames[1]);
+                        println!("{} {}", topic, payload.trim_end());
+                    } else {
+                        println!("recv {:?}", frames);
+                    }
                 }
-            }
-            Err(e) => {
-                eprintln!("recv error: {}", e);
-                break;
+                Err(e) => {
+                    eprintln!("recv error: {}", e);
+                    break;
+                }
             }
         }
     }
 }
 
+#[cfg(not(feature = "zmq-sink"))]
+fn main() {
+    eprintln!("zmq feature not enabled; rebuild with --features zmq-sink");
+}
+
+#[cfg(feature = "zmq-sink")]
+fn main() {
+    impls::run();
+}

--- a/src/cluster/crypto.rs
+++ b/src/cluster/crypto.rs
@@ -5,17 +5,39 @@ use serde_json;
 pub struct CryptoHandler;
 
 impl ClusterHandler for CryptoHandler {
-    fn ws_url(&self) -> &str { "wss://socket.polygon.io/crypto" }
-    fn default_subscription(&self) -> &str { "T.*" }
+    fn ws_url(&self) -> &str {
+        "wss://socket.polygon.io/crypto"
+    }
+    fn default_subscription(&self) -> &str {
+        "T.*"
+    }
 
-    fn normalize_messages(&self, text: &str) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
+    fn normalize_messages(
+        &self,
+        text: &str,
+    ) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
         let msgs: Vec<PolygonCryptoMessage> = serde_json::from_str(text)?;
         let mut out = Vec::with_capacity(msgs.len());
         for m in msgs {
             match m {
-                PolygonCryptoMessage::Status(status) => out.push(NormalizedEvent { ev: "status".to_string(), symbol: None, ts: None, payload: serde_json::to_value(status)? }),
-                PolygonCryptoMessage::Trade(tr) => out.push(NormalizedEvent { ev: "T".to_string(), symbol: Some(tr.symbol.clone()), ts: Some(tr.timestamp), payload: serde_json::to_value(tr)? }),
-                PolygonCryptoMessage::Quote(q) => out.push(NormalizedEvent { ev: "Q".to_string(), symbol: Some(q.symbol.clone()), ts: Some(q.ts), payload: serde_json::to_value(q)? }),
+                PolygonCryptoMessage::Status(status) => out.push(NormalizedEvent {
+                    ev: "status".to_string(),
+                    symbol: None,
+                    ts: None,
+                    payload: serde_json::to_value(status)?,
+                }),
+                PolygonCryptoMessage::Trade(tr) => out.push(NormalizedEvent {
+                    ev: "T".to_string(),
+                    symbol: Some(tr.symbol.clone()),
+                    ts: Some(tr.timestamp),
+                    payload: serde_json::to_value(tr)?,
+                }),
+                PolygonCryptoMessage::Quote(q) => out.push(NormalizedEvent {
+                    ev: "Q".to_string(),
+                    symbol: Some(q.symbol.clone()),
+                    ts: Some(q.ts),
+                    payload: serde_json::to_value(q)?,
+                }),
             }
         }
         Ok(out)

--- a/src/cluster/futures.rs
+++ b/src/cluster/futures.rs
@@ -5,17 +5,39 @@ use serde_json;
 pub struct FuturesHandler;
 
 impl ClusterHandler for FuturesHandler {
-    fn ws_url(&self) -> &str { "wss://socket.polygon.io/futures" }
-    fn default_subscription(&self) -> &str { "T.*" }
+    fn ws_url(&self) -> &str {
+        "wss://socket.polygon.io/futures"
+    }
+    fn default_subscription(&self) -> &str {
+        "T.*"
+    }
 
-    fn normalize_messages(&self, text: &str) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
+    fn normalize_messages(
+        &self,
+        text: &str,
+    ) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
         let msgs: Vec<PolygonFuturesMessage> = serde_json::from_str(text)?;
         let mut out = Vec::with_capacity(msgs.len());
         for m in msgs {
             match m {
-                PolygonFuturesMessage::Status(status) => out.push(NormalizedEvent { ev: "status".to_string(), symbol: None, ts: None, payload: serde_json::to_value(status)? }),
-                PolygonFuturesMessage::Trade(tr) => out.push(NormalizedEvent { ev: "T".to_string(), symbol: Some(tr.symbol.clone()), ts: Some(tr.timestamp), payload: serde_json::to_value(tr)? }),
-                PolygonFuturesMessage::Quote(q) => out.push(NormalizedEvent { ev: "Q".to_string(), symbol: Some(q.symbol.clone()), ts: Some(q.sip_ts), payload: serde_json::to_value(q)? }),
+                PolygonFuturesMessage::Status(status) => out.push(NormalizedEvent {
+                    ev: "status".to_string(),
+                    symbol: None,
+                    ts: None,
+                    payload: serde_json::to_value(status)?,
+                }),
+                PolygonFuturesMessage::Trade(tr) => out.push(NormalizedEvent {
+                    ev: "T".to_string(),
+                    symbol: Some(tr.symbol.clone()),
+                    ts: Some(tr.timestamp),
+                    payload: serde_json::to_value(tr)?,
+                }),
+                PolygonFuturesMessage::Quote(q) => out.push(NormalizedEvent {
+                    ev: "Q".to_string(),
+                    symbol: Some(q.symbol.clone()),
+                    ts: Some(q.sip_ts),
+                    payload: serde_json::to_value(q)?,
+                }),
             }
         }
         Ok(out)

--- a/src/cluster/generic.rs
+++ b/src/cluster/generic.rs
@@ -1,28 +1,56 @@
 use super::{ClusterHandler, NormalizedEvent};
 use serde_json::Value;
 
-pub enum ClusterKind { Named(String) }
+pub enum ClusterKind {
+    Named(String),
+}
 
-pub struct GenericHandler { url: String }
+pub struct GenericHandler {
+    url: String,
+}
 
 impl GenericHandler {
     pub fn new(kind: ClusterKind) -> Self {
-        match kind { ClusterKind::Named(n) => Self { url: format!("wss://socket.polygon.io/{}", n) } }
+        match kind {
+            ClusterKind::Named(n) => Self {
+                url: format!("wss://socket.polygon.io/{}", n),
+            },
+        }
     }
 }
 
 impl ClusterHandler for GenericHandler {
-    fn ws_url(&self) -> &str { &self.url }
-    fn default_subscription(&self) -> &str { "T.*" }
+    fn ws_url(&self) -> &str {
+        &self.url
+    }
+    fn default_subscription(&self) -> &str {
+        "T.*"
+    }
 
-    fn normalize_messages(&self, text: &str) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
+    fn normalize_messages(
+        &self,
+        text: &str,
+    ) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
         let vals: Vec<Value> = serde_json::from_str(text)?;
         let mut out = Vec::with_capacity(vals.len());
         for v in vals.into_iter() {
-            let ev = v.get("ev").and_then(|x| x.as_str()).unwrap_or("").to_string();
+            let ev = v
+                .get("ev")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
             let symbol = v.get("sym").and_then(|x| x.as_str()).map(|s| s.to_string());
-            let ts = v.get("ts").and_then(|x| x.as_i64()).or_else(|| v.get("t").and_then(|x| x.as_i64())).or_else(|| v.get("sip_ts").and_then(|x| x.as_i64()));
-            out.push(NormalizedEvent { ev, symbol, ts, payload: v });
+            let ts = v
+                .get("ts")
+                .and_then(|x| x.as_i64())
+                .or_else(|| v.get("t").and_then(|x| x.as_i64()))
+                .or_else(|| v.get("sip_ts").and_then(|x| x.as_i64()));
+            out.push(NormalizedEvent {
+                ev,
+                symbol,
+                ts,
+                payload: v,
+            });
         }
         Ok(out)
     }

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 #[derive(Debug, Clone)]
 pub struct NormalizedEvent {
-    pub ev: String,         // e.g., "T", "Q", "A", "AM", "status"
+    pub ev: String, // e.g., "T", "Q", "A", "AM", "status"
     pub symbol: Option<String>,
     pub ts: Option<i64>,
     pub payload: Value,
@@ -10,21 +10,26 @@ pub struct NormalizedEvent {
 
 pub trait ClusterHandler: Send + Sync {
     fn ws_url(&self) -> &str;
-    fn default_subscription(&self) -> &str { "T.*" }
-    fn normalize_messages(&self, text: &str) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>>;
+    fn default_subscription(&self) -> &str {
+        "T.*"
+    }
+    fn normalize_messages(
+        &self,
+        text: &str,
+    ) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>>;
 }
 
-mod stocks;
-mod futures;
-mod options;
 mod crypto;
+mod futures;
 mod generic;
+mod options;
+mod stocks;
 
-pub use stocks::StocksHandler;
-pub use futures::FuturesHandler;
-pub use options::OptionsHandler;
 pub use crypto::CryptoHandler;
-pub use generic::{GenericHandler, ClusterKind};
+pub use futures::FuturesHandler;
+pub use generic::{ClusterKind, GenericHandler};
+pub use options::OptionsHandler;
+pub use stocks::StocksHandler;
 
 pub fn build_handler(cluster: &str) -> Box<dyn ClusterHandler> {
     match cluster.to_ascii_lowercase().as_str() {
@@ -45,10 +50,22 @@ mod tests {
 
     #[test]
     fn ws_url_maps_correctly() {
-        assert_eq!(build_handler("stocks").ws_url(), "wss://socket.polygon.io/stocks");
-        assert_eq!(build_handler("futures").ws_url(), "wss://socket.polygon.io/futures");
-        assert_eq!(build_handler("options").ws_url(), "wss://socket.polygon.io/options");
-        assert_eq!(build_handler("crypto").ws_url(), "wss://socket.polygon.io/crypto");
+        assert_eq!(
+            build_handler("stocks").ws_url(),
+            "wss://socket.polygon.io/stocks"
+        );
+        assert_eq!(
+            build_handler("futures").ws_url(),
+            "wss://socket.polygon.io/futures"
+        );
+        assert_eq!(
+            build_handler("options").ws_url(),
+            "wss://socket.polygon.io/options"
+        );
+        assert_eq!(
+            build_handler("crypto").ws_url(),
+            "wss://socket.polygon.io/crypto"
+        );
     }
 
     #[test]

--- a/src/cluster/options.rs
+++ b/src/cluster/options.rs
@@ -5,17 +5,39 @@ use serde_json;
 pub struct OptionsHandler;
 
 impl ClusterHandler for OptionsHandler {
-    fn ws_url(&self) -> &str { "wss://socket.polygon.io/options" }
-    fn default_subscription(&self) -> &str { "T.*" }
+    fn ws_url(&self) -> &str {
+        "wss://socket.polygon.io/options"
+    }
+    fn default_subscription(&self) -> &str {
+        "T.*"
+    }
 
-    fn normalize_messages(&self, text: &str) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
+    fn normalize_messages(
+        &self,
+        text: &str,
+    ) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
         let msgs: Vec<PolygonOptionsMessage> = serde_json::from_str(text)?;
         let mut out = Vec::with_capacity(msgs.len());
         for m in msgs {
             match m {
-                PolygonOptionsMessage::Status(status) => out.push(NormalizedEvent { ev: "status".to_string(), symbol: None, ts: None, payload: serde_json::to_value(status)? }),
-                PolygonOptionsMessage::Trade(tr) => out.push(NormalizedEvent { ev: "T".to_string(), symbol: Some(tr.symbol.clone()), ts: Some(tr.timestamp), payload: serde_json::to_value(tr)? }),
-                PolygonOptionsMessage::Quote(q) => out.push(NormalizedEvent { ev: "Q".to_string(), symbol: Some(q.symbol.clone()), ts: Some(q.ts), payload: serde_json::to_value(q)? }),
+                PolygonOptionsMessage::Status(status) => out.push(NormalizedEvent {
+                    ev: "status".to_string(),
+                    symbol: None,
+                    ts: None,
+                    payload: serde_json::to_value(status)?,
+                }),
+                PolygonOptionsMessage::Trade(tr) => out.push(NormalizedEvent {
+                    ev: "T".to_string(),
+                    symbol: Some(tr.symbol.clone()),
+                    ts: Some(tr.timestamp),
+                    payload: serde_json::to_value(tr)?,
+                }),
+                PolygonOptionsMessage::Quote(q) => out.push(NormalizedEvent {
+                    ev: "Q".to_string(),
+                    symbol: Some(q.symbol.clone()),
+                    ts: Some(q.ts),
+                    payload: serde_json::to_value(q)?,
+                }),
             }
         }
         Ok(out)

--- a/src/cluster/stocks.rs
+++ b/src/cluster/stocks.rs
@@ -1,23 +1,55 @@
 use super::{ClusterHandler, NormalizedEvent};
-use crate::model::{PolygonStockMessage};
+use crate::model::PolygonStockMessage;
 use serde_json;
 
 pub struct StocksHandler;
 
 impl ClusterHandler for StocksHandler {
-    fn ws_url(&self) -> &str { "wss://socket.polygon.io/stocks" }
-    fn default_subscription(&self) -> &str { "T.*" }
+    fn ws_url(&self) -> &str {
+        "wss://socket.polygon.io/stocks"
+    }
+    fn default_subscription(&self) -> &str {
+        "T.*"
+    }
 
-    fn normalize_messages(&self, text: &str) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
+    fn normalize_messages(
+        &self,
+        text: &str,
+    ) -> Result<Vec<NormalizedEvent>, Box<dyn std::error::Error>> {
         let msgs: Vec<PolygonStockMessage> = serde_json::from_str(text)?;
         let mut out = Vec::with_capacity(msgs.len());
         for m in msgs {
             match m {
-                PolygonStockMessage::Status(status) => out.push(NormalizedEvent { ev: "status".to_string(), symbol: None, ts: None, payload: serde_json::to_value(status)? }),
-                PolygonStockMessage::Trade(tr) => out.push(NormalizedEvent { ev: "T".to_string(), symbol: Some(tr.symbol.clone()), ts: Some(tr.timestamp), payload: serde_json::to_value(tr)? }),
-                PolygonStockMessage::AggregateSecond(ag) => out.push(NormalizedEvent { ev: "A".to_string(), symbol: Some(ag.symbol.clone()), ts: Some(ag.end_ts), payload: serde_json::to_value(ag)? }),
-                PolygonStockMessage::AggregateMinute(ag) => out.push(NormalizedEvent { ev: "AM".to_string(), symbol: Some(ag.symbol.clone()), ts: Some(ag.end_ts), payload: serde_json::to_value(ag)? }),
-                PolygonStockMessage::Quote(q) => out.push(NormalizedEvent { ev: "Q".to_string(), symbol: Some(q.symbol.clone()), ts: Some(q.sip_ts), payload: serde_json::to_value(q)? }),
+                PolygonStockMessage::Status(status) => out.push(NormalizedEvent {
+                    ev: "status".to_string(),
+                    symbol: None,
+                    ts: None,
+                    payload: serde_json::to_value(status)?,
+                }),
+                PolygonStockMessage::Trade(tr) => out.push(NormalizedEvent {
+                    ev: "T".to_string(),
+                    symbol: Some(tr.symbol.clone()),
+                    ts: Some(tr.timestamp),
+                    payload: serde_json::to_value(tr)?,
+                }),
+                PolygonStockMessage::AggregateSecond(ag) => out.push(NormalizedEvent {
+                    ev: "A".to_string(),
+                    symbol: Some(ag.symbol.clone()),
+                    ts: Some(ag.end_ts),
+                    payload: serde_json::to_value(ag)?,
+                }),
+                PolygonStockMessage::AggregateMinute(ag) => out.push(NormalizedEvent {
+                    ev: "AM".to_string(),
+                    symbol: Some(ag.symbol.clone()),
+                    ts: Some(ag.end_ts),
+                    payload: serde_json::to_value(ag)?,
+                }),
+                PolygonStockMessage::Quote(q) => out.push(NormalizedEvent {
+                    ev: "Q".to_string(),
+                    symbol: Some(q.symbol.clone()),
+                    ts: Some(q.sip_ts),
+                    payload: serde_json::to_value(q)?,
+                }),
             }
         }
         Ok(out)

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,7 @@ pub struct Config {
     pub ndjson_reopen_on_hup: bool,
     pub ndjson_flush_every: usize,
     pub ndjson_flush_interval: Duration,
-    pub ndjson_include: Option<Vec<String>>, 
+    pub ndjson_include: Option<Vec<String>>,
     pub ndjson_sample_quotes: u64,
     pub ndjson_split_per_type: bool,
 
@@ -41,12 +41,11 @@ pub struct Config {
 
 impl Config {
     pub fn from_env() -> Result<Self, Box<dyn std::error::Error>> {
-        let api_key = env::var("POLYGON_API_KEY")
-            .map_err(|_| "POLYGON_API_KEY is not set".to_string())?;
+        let api_key =
+            env::var("POLYGON_API_KEY").map_err(|_| "POLYGON_API_KEY is not set".to_string())?;
 
         let cluster = env::var("POLYGON_CLUSTER").unwrap_or_else(|_| "futures".to_string());
-        let subscription = env::var("SUBSCRIPTION")
-            .unwrap_or_else(|_| "T.*".to_string());
+        let subscription = env::var("SUBSCRIPTION").unwrap_or_else(|_| "T.*".to_string());
 
         let channel_capacity = env::var("CHANNEL_CAP")
             .ok()
@@ -74,16 +73,32 @@ impl Config {
         let heartbeat_interval = env::var("HEARTBEAT_INTERVAL_SECS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
-            .map(|secs| if secs == 0 { None } else { Some(Duration::from_secs(secs)) })
+            .map(|secs| {
+                if secs == 0 {
+                    None
+                } else {
+                    Some(Duration::from_secs(secs))
+                }
+            })
             .unwrap_or_else(|| Some(Duration::from_secs(30)));
 
-        let metrics_addr = env::var("METRICS_ADDR").unwrap_or_else(|_| "127.0.0.1:9898".to_string());
+        let metrics_addr =
+            env::var("METRICS_ADDR").unwrap_or_else(|_| "127.0.0.1:9898".to_string());
 
-        let ready_min_messages = env::var("READY_MIN_MESSAGES").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(1);
-        let ready_delay = env::var("READY_DELAY_MS").ok().and_then(|v| v.parse::<u64>().ok()).map(Duration::from_millis).unwrap_or_else(|| Duration::from_millis(0));
+        let ready_min_messages = env::var("READY_MIN_MESSAGES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(1);
+        let ready_delay = env::var("READY_DELAY_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(Duration::from_millis)
+            .unwrap_or_else(|| Duration::from_millis(0));
 
-        let reconnect_buckets = parse_buckets(env::var("RECONNECT_BUCKETS").ok().as_deref()).unwrap_or_else(|| vec![0.1,0.5,1.0,2.0,5.0,10.0,30.0,60.0]);
-        let interarrival_buckets = parse_buckets(env::var("INTERARRIVAL_BUCKETS").ok().as_deref()).unwrap_or_else(|| vec![0.001,0.005,0.01,0.05,0.1,0.5,1.0,2.0,5.0]);
+        let reconnect_buckets = parse_buckets(env::var("RECONNECT_BUCKETS").ok().as_deref())
+            .unwrap_or_else(|| vec![0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0]);
+        let interarrival_buckets = parse_buckets(env::var("INTERARRIVAL_BUCKETS").ok().as_deref())
+            .unwrap_or_else(|| vec![0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0]);
 
         let bp_warn_interval = env::var("BP_WARN_INTERVAL_SECS")
             .ok()
@@ -117,27 +132,66 @@ impl Config {
             bp_warn_interval,
             stats_interval,
             ndjson_dest: env::var("NDJSON_DEST").unwrap_or_else(|_| "stdout".to_string()),
-            ndjson_channel_cap: env::var("NDJSON_CHANNEL_CAP").ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(2048),
-            ndjson_warn_interval: env::var("NDJSON_WARN_INTERVAL_SECS").ok().and_then(|v| v.parse::<u64>().ok()).map(Duration::from_secs).unwrap_or_else(|| Duration::from_secs(5)),
-            ndjson_max_bytes: env::var("NDJSON_MAX_BYTES").ok().and_then(|v| v.parse::<u64>().ok()),
-            ndjson_rotate_secs: env::var("NDJSON_ROTATE_SECS").ok().and_then(|v| v.parse::<u64>().ok()),
+            ndjson_channel_cap: env::var("NDJSON_CHANNEL_CAP")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(2048),
+            ndjson_warn_interval: env::var("NDJSON_WARN_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(Duration::from_secs)
+                .unwrap_or_else(|| Duration::from_secs(5)),
+            ndjson_max_bytes: env::var("NDJSON_MAX_BYTES")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok()),
+            ndjson_rotate_secs: env::var("NDJSON_ROTATE_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok()),
             ndjson_gzip: parse_bool(env::var("NDJSON_GZIP").ok().as_deref()),
             ndjson_reopen_on_hup: !parse_bool(env::var("NDJSON_NO_REOPEN").ok().as_deref()),
-            ndjson_flush_every: env::var("NDJSON_FLUSH_EVERY").ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(100),
-            ndjson_flush_interval: env::var("NDJSON_FLUSH_INTERVAL_MS").ok().and_then(|v| v.parse::<u64>().ok()).map(Duration::from_millis).unwrap_or_else(|| Duration::from_millis(1000)),
+            ndjson_flush_every: env::var("NDJSON_FLUSH_EVERY")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(100),
+            ndjson_flush_interval: env::var("NDJSON_FLUSH_INTERVAL_MS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(Duration::from_millis)
+                .unwrap_or_else(|| Duration::from_millis(1000)),
             ndjson_include: env::var("NDJSON_INCLUDE").ok().and_then(|v| {
-                let pats: Vec<String> = v.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
-                if pats.is_empty() { None } else { Some(pats) }
+                let pats: Vec<String> = v
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                if pats.is_empty() {
+                    None
+                } else {
+                    Some(pats)
+                }
             }),
-            ndjson_sample_quotes: env::var("NDJSON_SAMPLE_QUOTES").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(1),
+            ndjson_sample_quotes: env::var("NDJSON_SAMPLE_QUOTES")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(1),
             ndjson_split_per_type: parse_bool(env::var("NDJSON_SPLIT_PER_TYPE").ok().as_deref()),
 
             // ZMQ sink
-            zmq_endpoint: env::var("ZMQ_ENDPOINT").unwrap_or_else(|_| "tcp://127.0.0.1:5556".to_string()),
+            zmq_endpoint: env::var("ZMQ_ENDPOINT")
+                .unwrap_or_else(|_| "tcp://127.0.0.1:5556".to_string()),
             zmq_bind: parse_bool(env::var("ZMQ_BIND").ok().as_deref()),
-            zmq_channel_cap: env::var("ZMQ_CHANNEL_CAP").ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(4096),
-            zmq_warn_interval: env::var("ZMQ_WARN_INTERVAL_SECS").ok().and_then(|v| v.parse::<u64>().ok()).map(Duration::from_secs).unwrap_or_else(|| Duration::from_secs(5)),
-            zmq_snd_hwm: env::var("ZMQ_SND_HWM").ok().and_then(|v| v.parse::<i32>().ok()),
+            zmq_channel_cap: env::var("ZMQ_CHANNEL_CAP")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(4096),
+            zmq_warn_interval: env::var("ZMQ_WARN_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(Duration::from_secs)
+                .unwrap_or_else(|| Duration::from_secs(5)),
+            zmq_snd_hwm: env::var("ZMQ_SND_HWM")
+                .ok()
+                .and_then(|v| v.parse::<i32>().ok()),
             zmq_topic_prefix: env::var("ZMQ_TOPIC_PREFIX").unwrap_or_else(|_| "".to_string()),
         })
     }
@@ -147,10 +201,19 @@ fn parse_buckets(src: Option<&str>) -> Option<Vec<f64>> {
     let s = src?;
     let mut out = Vec::new();
     for part in s.split(',') {
-        if part.trim().is_empty() { continue; }
-        if let Ok(v) = part.trim().parse::<f64>() { out.push(v); }
+        if part.trim().is_empty() {
+            continue;
+        }
+        if let Ok(v) = part.trim().parse::<f64>() {
+            out.push(v);
+        }
     }
-    if out.is_empty() { None } else { out.sort_by(|a,b| a.partial_cmp(b).unwrap()); Some(out) }
+    if out.is_empty() {
+        None
+    } else {
+        out.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        Some(out)
+    }
 }
 
 fn parse_bool(src: Option<&str>) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,8 +17,6 @@ pub struct Config {
     pub interarrival_buckets: Vec<f64>,
     pub bp_warn_interval: Duration,
     pub stats_interval: Duration,
-    #[allow(dead_code)]
-    pub emit_ndjson: bool,
     pub ndjson_dest: String,
     pub ndjson_channel_cap: usize,
     pub ndjson_warn_interval: Duration,
@@ -99,10 +97,7 @@ impl Config {
             .map(Duration::from_secs)
             .unwrap_or_else(|| Duration::from_secs(60));
 
-        let sink = env::var("SINK").unwrap_or_else(|_| {
-            // Back-compat: if EMIT_NDJSON=true, prefer ndjson; else stdout
-            if parse_bool(env::var("EMIT_NDJSON").ok().as_deref()) { "ndjson".to_string() } else { "stdout".to_string() }
-        });
+        let sink = env::var("SINK").unwrap_or_else(|_| "stdout".to_string());
 
         Ok(Config {
             sink,
@@ -121,7 +116,6 @@ impl Config {
             interarrival_buckets,
             bp_warn_interval,
             stats_interval,
-            emit_ndjson: parse_bool(env::var("EMIT_NDJSON").ok().as_deref()),
             ndjson_dest: env::var("NDJSON_DEST").unwrap_or_else(|_| "stdout".to_string()),
             ndjson_channel_cap: env::var("NDJSON_CHANNEL_CAP").ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(2048),
             ndjson_warn_interval: env::var("NDJSON_WARN_INTERVAL_SECS").ok().and_then(|v| v.parse::<u64>().ok()).map(Duration::from_secs).unwrap_or_else(|| Duration::from_secs(5)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -420,7 +420,8 @@ fn record_sink_backpressure(metrics: &Metrics, bp: &mut NdjsonBp) {
         } else {
             warn!(target: "polygon_ndjson", dropped = bp.dropped_since_warn, interval_secs = bp.warn_interval.as_secs(), "ndjson_backpressure");
         }
-        bp.dropped_since_warn = 0; bp.last_warn = Instant::now();
+        bp.dropped_since_warn = 0;
+        bp.last_warn = Instant::now();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,7 +630,7 @@ fn process_message(
             let payload_json = serde_json::to_string(&ev.payload)?;
             buf.extend_from_slice(payload_json.as_bytes());
             let line = std::str::from_utf8(&buf)?;
-            info!(target: "polygon_events", r#type = %ev.ev, symbol = %ev.symbol.clone().unwrap_or_default(), ts = ev.ts.unwrap_or(0), payload = %payload_json, line = %line);
+            info!(target: "polygon_events", r#type = %ev.ev, symbol = %ev.symbol.as_deref().unwrap_or(""), ts = ev.ts.unwrap_or(0), payload = %payload_json, line = %line);
 
             // NDJSON emission
             let choose_tx = match ev.ev.as_str() { "T" => ndjson_trades_tx.or(ndjson_tx), "Q" => ndjson_quotes_tx.or(ndjson_tx), _ => ndjson_tx };
@@ -640,7 +640,7 @@ fn process_message(
                 // Include filters
                 if let Some(ref pats) = ndjson_bp.include {
                     let kind = ev.ev.chars().next().unwrap_or('*');
-                    let sym = ev.symbol.clone().unwrap_or_default();
+                    let sym = ev.symbol.as_deref().unwrap_or("");
                     let mut matched = false;
                     for p in pats.iter() {
                         if p.kind == kind || p.kind == '*' {
@@ -652,7 +652,7 @@ fn process_message(
                 ndjson_bp.seq_counter = ndjson_bp.seq_counter.saturating_add(1);
                 let ev_out = make_ndjson_event(
                     &ev.ev,
-                    &ev.symbol.clone().unwrap_or_default(),
+                    ev.symbol.as_deref().unwrap_or(""),
                     ev.ts.unwrap_or(0),
                     ev.payload.clone(),
                     metrics,

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,7 +435,7 @@ fn make_ndjson_event(
 ) -> NdjsonEvent {
     NdjsonEvent {
         ingest_ts: now_millis(),
-        r#type: typ.to_string(),
+        r#type: ndjson::intern_event_type(typ),
         symbol: symbol.to_string(),
         topic: metrics.topic().to_string(),
         feed: metrics.feed().to_string(),
@@ -654,7 +654,7 @@ fn process_message(
                     &ev.ev,
                     ev.symbol.as_deref().unwrap_or(""),
                     ev.ts.unwrap_or(0),
-                    ev.payload.clone(),
+                    ev.payload,
                     metrics,
                     host,
                     ndjson_bp.seq_counter,

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,7 +435,7 @@ fn make_ndjson_event(
 ) -> NdjsonEvent {
     NdjsonEvent {
         ingest_ts: now_millis(),
-        r#type: Box::leak(typ.to_string().into_boxed_str()),
+        r#type: typ.to_string(),
         symbol: symbol.to_string(),
         topic: metrics.topic().to_string(),
         feed: metrics.feed().to_string(),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,11 +1,11 @@
 use std::io::Write;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, AtomicBool, Ordering};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Notify;
-use tracing::{info, warn, error, debug};
 use tokio::time::{interval, MissedTickBehavior};
+use tracing::{debug, error, info, warn};
 
 #[derive(Clone)]
 pub struct Metrics {
@@ -32,7 +32,12 @@ pub struct Metrics {
 }
 
 impl Metrics {
-    pub fn new(feed: String, topic: String, reconnect_buckets: Vec<f64>, interarrival_buckets: Vec<f64>) -> Self {
+    pub fn new(
+        feed: String,
+        topic: String,
+        reconnect_buckets: Vec<f64>,
+        interarrival_buckets: Vec<f64>,
+    ) -> Self {
         Metrics {
             reconnects_total: Arc::new(AtomicU64::new(0)),
             reconnect_success_total: Arc::new(AtomicU64::new(0)),
@@ -57,23 +62,57 @@ impl Metrics {
         }
     }
 
-    pub fn inc_reconnect(&self) { self.reconnects_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_reconnect_success(&self) { self.reconnect_success_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_reconnect_failure(&self) { self.reconnect_failure_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_timeout(&self) { self.read_timeouts_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_heartbeat(&self) { self.heartbeats_sent_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_received(&self) { self.messages_received_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_trade(&self) { self.trades_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_quote(&self) { self.quotes_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_status(&self) { self.status_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_error(&self) { self.errors_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_drop(&self) { self.channel_drops_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_ndjson_drop(&self) { self.ndjson_drops_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_ndjson_written(&self) { self.ndjson_written_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_zmq_drop(&self) { self.zmq_drops_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn inc_zmq_sent(&self) { self.zmq_sent_total.fetch_add(1, Ordering::Relaxed); }
-    pub fn set_ready(&self, v: bool) { self.ready.store(v, Ordering::Relaxed); }
-    pub fn is_ready(&self) -> bool { self.ready.load(Ordering::Relaxed) }
+    pub fn inc_reconnect(&self) {
+        self.reconnects_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_reconnect_success(&self) {
+        self.reconnect_success_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_reconnect_failure(&self) {
+        self.reconnect_failure_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_timeout(&self) {
+        self.read_timeouts_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_heartbeat(&self) {
+        self.heartbeats_sent_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_received(&self) {
+        self.messages_received_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_trade(&self) {
+        self.trades_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_quote(&self) {
+        self.quotes_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_status(&self) {
+        self.status_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_error(&self) {
+        self.errors_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_drop(&self) {
+        self.channel_drops_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_ndjson_drop(&self) {
+        self.ndjson_drops_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_ndjson_written(&self) {
+        self.ndjson_written_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_zmq_drop(&self) {
+        self.zmq_drops_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn inc_zmq_sent(&self) {
+        self.zmq_sent_total.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn set_ready(&self, v: bool) {
+        self.ready.store(v, Ordering::Relaxed);
+    }
+    pub fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Relaxed)
+    }
 
     pub fn render_prometheus(&self) -> String {
         let mut s = Vec::with_capacity(512);
@@ -82,79 +121,203 @@ impl Metrics {
         let version = env!("CARGO_PKG_VERSION");
         let _ = writeln!(&mut s, "# HELP polygon_build_info Build information");
         let _ = writeln!(&mut s, "# TYPE polygon_build_info gauge");
-        let _ = writeln!(&mut s, "polygon_build_info{{name=\"{}\",version=\"{}\"}} 1", name, version);
+        let _ = writeln!(
+            &mut s,
+            "polygon_build_info{{name=\"{}\",version=\"{}\"}} 1",
+            name, version
+        );
 
         let labels = format!("feed=\"{}\",topic=\"{}\"", self.feed, self.topic);
 
         let _ = writeln!(&mut s, "# HELP polygon_reconnects_total Reconnect attempts");
         let _ = writeln!(&mut s, "# TYPE polygon_reconnects_total counter");
-        let _ = writeln!(&mut s, "polygon_reconnects_total{{{}}} {}", labels, self.reconnects_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_reconnects_total{{{}}} {}",
+            labels,
+            self.reconnects_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_reconnect_success_total Successful reconnect cycles");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_reconnect_success_total Successful reconnect cycles"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_reconnect_success_total counter");
-        let _ = writeln!(&mut s, "polygon_reconnect_success_total{{{}}} {}", labels, self.reconnect_success_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_reconnect_success_total{{{}}} {}",
+            labels,
+            self.reconnect_success_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_reconnect_failure_total Failed reconnect attempts before retry");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_reconnect_failure_total Failed reconnect attempts before retry"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_reconnect_failure_total counter");
-        let _ = writeln!(&mut s, "polygon_reconnect_failure_total{{{}}} {}", labels, self.reconnect_failure_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_reconnect_failure_total{{{}}} {}",
+            labels,
+            self.reconnect_failure_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_read_timeouts_total Read timeouts on the WebSocket");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_read_timeouts_total Read timeouts on the WebSocket"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_read_timeouts_total counter");
-        let _ = writeln!(&mut s, "polygon_read_timeouts_total{{{}}} {}", labels, self.read_timeouts_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_read_timeouts_total{{{}}} {}",
+            labels,
+            self.read_timeouts_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_heartbeats_sent_total Heartbeat pings sent");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_heartbeats_sent_total Heartbeat pings sent"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_heartbeats_sent_total counter");
-        let _ = writeln!(&mut s, "polygon_heartbeats_sent_total{{{}}} {}", labels, self.heartbeats_sent_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_heartbeats_sent_total{{{}}} {}",
+            labels,
+            self.heartbeats_sent_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_messages_received_total WebSocket messages received");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_messages_received_total WebSocket messages received"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_messages_received_total counter");
-        let _ = writeln!(&mut s, "polygon_messages_received_total{{{}}} {}", labels, self.messages_received_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_messages_received_total{{{}}} {}",
+            labels,
+            self.messages_received_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_trades_total Futures trade messages processed");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_trades_total Futures trade messages processed"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_trades_total counter");
-        let _ = writeln!(&mut s, "polygon_trades_total{{{}}} {}", labels, self.trades_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_trades_total{{{}}} {}",
+            labels,
+            self.trades_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_quotes_total Futures quote messages processed");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_quotes_total Futures quote messages processed"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_quotes_total counter");
-        let _ = writeln!(&mut s, "polygon_quotes_total{{{}}} {}", labels, self.quotes_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_quotes_total{{{}}} {}",
+            labels,
+            self.quotes_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_status_total Status messages processed");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_status_total Status messages processed"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_status_total counter");
-        let _ = writeln!(&mut s, "polygon_status_total{{{}}} {}", labels, self.status_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_status_total{{{}}} {}",
+            labels,
+            self.status_total.load(Ordering::Relaxed)
+        );
 
         let _ = writeln!(&mut s, "# HELP polygon_errors_total Errors encountered");
         let _ = writeln!(&mut s, "# TYPE polygon_errors_total counter");
-        let _ = writeln!(&mut s, "polygon_errors_total{{{}}} {}", labels, self.errors_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_errors_total{{{}}} {}",
+            labels,
+            self.errors_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_channel_drops_total Messages dropped due to backpressure");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_channel_drops_total Messages dropped due to backpressure"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_channel_drops_total counter");
-        let _ = writeln!(&mut s, "polygon_channel_drops_total{{{}}} {}", labels, self.channel_drops_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_channel_drops_total{{{}}} {}",
+            labels,
+            self.channel_drops_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_ndjson_drops_total NDJSON messages dropped due to backpressure");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_ndjson_drops_total NDJSON messages dropped due to backpressure"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_ndjson_drops_total counter");
-        let _ = writeln!(&mut s, "polygon_ndjson_drops_total{{{}}} {}", labels, self.ndjson_drops_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_ndjson_drops_total{{{}}} {}",
+            labels,
+            self.ndjson_drops_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_ndjson_written_total NDJSON messages written");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_ndjson_written_total NDJSON messages written"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_ndjson_written_total counter");
-        let _ = writeln!(&mut s, "polygon_ndjson_written_total{{{}}} {}", labels, self.ndjson_written_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_ndjson_written_total{{{}}} {}",
+            labels,
+            self.ndjson_written_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_zmq_drops_total ZMQ send drops due to backpressure");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_zmq_drops_total ZMQ send drops due to backpressure"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_zmq_drops_total counter");
-        let _ = writeln!(&mut s, "polygon_zmq_drops_total{{{}}} {}", labels, self.zmq_drops_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_zmq_drops_total{{{}}} {}",
+            labels,
+            self.zmq_drops_total.load(Ordering::Relaxed)
+        );
 
-        let _ = writeln!(&mut s, "# HELP polygon_zmq_sent_total ZMQ messages sent successfully");
+        let _ = writeln!(
+            &mut s,
+            "# HELP polygon_zmq_sent_total ZMQ messages sent successfully"
+        );
         let _ = writeln!(&mut s, "# TYPE polygon_zmq_sent_total counter");
-        let _ = writeln!(&mut s, "polygon_zmq_sent_total{{{}}} {}", labels, self.zmq_sent_total.load(Ordering::Relaxed));
+        let _ = writeln!(
+            &mut s,
+            "polygon_zmq_sent_total{{{}}} {}",
+            labels,
+            self.zmq_sent_total.load(Ordering::Relaxed)
+        );
 
         // Histograms
-        self.reconnect_hist_success.render("polygon_reconnect_duration_seconds", &labels, &mut s);
-        self.interarrival_hist.render("polygon_message_interarrival_seconds", &labels, &mut s);
+        self.reconnect_hist_success
+            .render("polygon_reconnect_duration_seconds", &labels, &mut s);
+        self.interarrival_hist
+            .render("polygon_message_interarrival_seconds", &labels, &mut s);
 
         String::from_utf8(s).unwrap_or_default()
     }
 }
 
-pub fn spawn_http_server(metrics: Metrics, addr: String, notify_shutdown: Arc<Notify>) -> tokio::task::JoinHandle<()> {
+pub fn spawn_http_server(
+    metrics: Metrics,
+    addr: String,
+    notify_shutdown: Arc<Notify>,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         match TcpListener::bind(&addr).await {
             Ok(listener) => {
@@ -190,23 +353,38 @@ pub fn spawn_http_server(metrics: Metrics, addr: String, notify_shutdown: Arc<No
     })
 }
 
-async fn handle_conn(mut socket: TcpStream, metrics: Metrics) -> Result<(), Box<dyn std::error::Error>> {
+async fn handle_conn(
+    mut socket: TcpStream,
+    metrics: Metrics,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = [0u8; 1024];
     let n = socket.read(&mut buf).await?;
     let req = std::str::from_utf8(&buf[..n]).unwrap_or("");
-    let (status, content_type, body) = if req.starts_with("GET /metrics ") || req.starts_with("GET /metrics\r") {
-        ("200 OK", "text/plain; version=0.0.4", metrics.render_prometheus())
-    } else if req.starts_with("GET /health ") || req.starts_with("GET /health\r") || req.starts_with("GET / ") {
-        ("200 OK", "text/plain", "OK".to_string())
-    } else if req.starts_with("GET /ready ") || req.starts_with("GET /ready\r") {
-        if metrics.is_ready() {
-            ("200 OK", "text/plain", "READY".to_string())
+    let (status, content_type, body) =
+        if req.starts_with("GET /metrics ") || req.starts_with("GET /metrics\r") {
+            (
+                "200 OK",
+                "text/plain; version=0.0.4",
+                metrics.render_prometheus(),
+            )
+        } else if req.starts_with("GET /health ")
+            || req.starts_with("GET /health\r")
+            || req.starts_with("GET / ")
+        {
+            ("200 OK", "text/plain", "OK".to_string())
+        } else if req.starts_with("GET /ready ") || req.starts_with("GET /ready\r") {
+            if metrics.is_ready() {
+                ("200 OK", "text/plain", "READY".to_string())
+            } else {
+                (
+                    "503 Service Unavailable",
+                    "text/plain",
+                    "NOT READY".to_string(),
+                )
+            }
         } else {
-            ("503 Service Unavailable", "text/plain", "NOT READY".to_string())
-        }
-    } else {
-        ("404 Not Found", "text/plain", "Not Found".to_string())
-    };
+            ("404 Not Found", "text/plain", "Not Found".to_string())
+        };
     let resp = format!(
         "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
         status,
@@ -219,7 +397,11 @@ async fn handle_conn(mut socket: TcpStream, metrics: Metrics) -> Result<(), Box<
     Ok(())
 }
 
-pub fn spawn_stats_logger(metrics: Metrics, notify_shutdown: Arc<Notify>, period: std::time::Duration) -> tokio::task::JoinHandle<()> {
+pub fn spawn_stats_logger(
+    metrics: Metrics,
+    notify_shutdown: Arc<Notify>,
+    period: std::time::Duration,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut last = Snapshot::from(&metrics);
         let mut tick = interval(period);
@@ -284,13 +466,22 @@ struct Histogram {
 
 impl Histogram {
     fn new(mut buckets: Vec<f64>) -> Self {
-        buckets.sort_by(|a,b| a.partial_cmp(b).unwrap());
+        buckets.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let counts = (0..buckets.len()).map(|_| AtomicU64::new(0)).collect();
-        Self { buckets, counts, sum_us: AtomicU64::new(0), count: AtomicU64::new(0) }
+        Self {
+            buckets,
+            counts,
+            sum_us: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
     }
 
     fn observe(&self, value_secs: f64) {
-        let us = if value_secs.is_sign_positive() { (value_secs * 1_000_000.0) as u64 } else { 0 };
+        let us = if value_secs.is_sign_positive() {
+            (value_secs * 1_000_000.0) as u64
+        } else {
+            0
+        };
         self.sum_us.fetch_add(us, Ordering::Relaxed);
         self.count.fetch_add(1, Ordering::Relaxed);
         for (i, b) in self.buckets.iter().enumerate() {
@@ -308,7 +499,11 @@ impl Histogram {
         for (i, b) in self.buckets.iter().enumerate() {
             let c = self.counts[i].load(Ordering::Relaxed);
             cumulative += c;
-            let _ = writeln!(out, "{}_bucket{{{},le=\"{}\"}} {}", name, labels, b, cumulative);
+            let _ = writeln!(
+                out,
+                "{}_bucket{{{},le=\"{}\"}} {}",
+                name, labels, b, cumulative
+            );
         }
         let total = self.count.load(Ordering::Relaxed);
         let _ = writeln!(out, "{}_bucket{{{},le=\"+Inf\"}} {}", name, labels, total);
@@ -319,9 +514,17 @@ impl Histogram {
 }
 
 impl Metrics {
-    pub fn observe_reconnect_success_secs(&self, secs: f64) { self.reconnect_hist_success.observe(secs); }
-    pub fn observe_interarrival_secs(&self, secs: f64) { self.interarrival_hist.observe(secs); }
+    pub fn observe_reconnect_success_secs(&self, secs: f64) {
+        self.reconnect_hist_success.observe(secs);
+    }
+    pub fn observe_interarrival_secs(&self, secs: f64) {
+        self.interarrival_hist.observe(secs);
+    }
 
-    pub fn feed(&self) -> &str { &self.feed }
-    pub fn topic(&self) -> &str { &self.topic }
+    pub fn feed(&self) -> &str {
+        &self.feed
+    }
+    pub fn topic(&self) -> &str {
+        &self.topic
+    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -542,8 +542,20 @@ mod tests {
         ]"#;
         let msgs: Vec<PolygonOptionsMessage> = serde_json::from_str(json_data).unwrap();
         assert_eq!(msgs.len(), 2);
-        match &msgs[0] { PolygonOptionsMessage::Trade(t) => { assert_eq!(t.symbol, "AAPL240118C00180000"); assert_eq!(t.size as i64, 10); }, _ => panic!("expected trade") }
-        match &msgs[1] { PolygonOptionsMessage::Quote(q) => { assert_eq!(q.symbol, "AAPL240118C00180000"); assert!((q.bid_price-1.2).abs()<1e-9); }, _ => panic!("expected quote") }
+        match &msgs[0] {
+            PolygonOptionsMessage::Trade(t) => {
+                assert_eq!(t.symbol, "AAPL240118C00180000");
+                assert_eq!(t.size as i64, 10);
+            }
+            _ => panic!("expected trade"),
+        }
+        match &msgs[1] {
+            PolygonOptionsMessage::Quote(q) => {
+                assert_eq!(q.symbol, "AAPL240118C00180000");
+                assert!((q.bid_price - 1.2).abs() < 1e-9);
+            }
+            _ => panic!("expected quote"),
+        }
     }
 
     #[test]
@@ -554,7 +566,19 @@ mod tests {
         ]"#;
         let msgs: Vec<PolygonCryptoMessage> = serde_json::from_str(json_data).unwrap();
         assert_eq!(msgs.len(), 2);
-        match &msgs[0] { PolygonCryptoMessage::Trade(t) => { assert_eq!(t.symbol, "BTC-USD"); assert!((t.price-40000.5).abs()<1e-9); }, _ => panic!("expected trade") }
-        match &msgs[1] { PolygonCryptoMessage::Quote(q) => { assert_eq!(q.symbol, "BTC-USD"); assert_eq!(q.bid_price as i64, 40000); }, _ => panic!("expected quote") }
+        match &msgs[0] {
+            PolygonCryptoMessage::Trade(t) => {
+                assert_eq!(t.symbol, "BTC-USD");
+                assert!((t.price - 40000.5).abs() < 1e-9);
+            }
+            _ => panic!("expected trade"),
+        }
+        match &msgs[1] {
+            PolygonCryptoMessage::Quote(q) => {
+                assert_eq!(q.symbol, "BTC-USD");
+                assert_eq!(q.bid_price as i64, 40000);
+            }
+            _ => panic!("expected quote"),
+        }
     }
 }

--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -17,7 +17,7 @@ use crate::metrics::Metrics;
 #[derive(Serialize)]
 pub struct NdjsonEvent {
     pub ingest_ts: i64,
-    pub r#type: &'static str,
+    pub r#type: String,
     pub symbol: String,
     pub topic: String,
     pub feed: String,

--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -6,6 +6,7 @@ use tokio::sync::Notify;
 use tracing::{warn, error};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::path::Path;
+use std::borrow::Cow;
 #[cfg(unix)]
 use tokio::signal::unix::{signal, SignalKind};
 use flate2::write::GzEncoder;
@@ -17,7 +18,7 @@ use crate::metrics::Metrics;
 #[derive(Serialize)]
 pub struct NdjsonEvent {
     pub ingest_ts: i64,
-    pub r#type: String,
+    pub r#type: Cow<'static, str>,
     pub symbol: String,
     pub topic: String,
     pub feed: String,
@@ -27,6 +28,17 @@ pub struct NdjsonEvent {
     pub app_version: &'static str,
     pub schema_version: u8,
     pub seq: u64,
+}
+
+pub fn intern_event_type(typ: &str) -> Cow<'static, str> {
+    match typ {
+        "T" => Cow::Borrowed("T"),
+        "Q" => Cow::Borrowed("Q"),
+        "A" => Cow::Borrowed("A"),
+        "AM" => Cow::Borrowed("AM"),
+        "status" => Cow::Borrowed("status"),
+        _ => Cow::Owned(typ.to_string()),
+    }
 }
 
 pub enum NdjsonDest {

--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -30,6 +30,10 @@ pub struct NdjsonEvent {
     pub seq: u64,
 }
 
+/// Interns common event types to avoid allocations.
+///
+/// Returns a borrowed static string for common types (T, Q, A, AM, status)
+/// and an owned string for any other event types.
 pub fn intern_event_type(typ: &str) -> Cow<'static, str> {
     match typ {
         "T" => Cow::Borrowed("T"),

--- a/src/sink_zmq.rs
+++ b/src/sink_zmq.rs
@@ -114,7 +114,8 @@ pub fn spawn_zmq_publisher(
                                         metrics.inc_zmq_drop();
                                         if last_warn.elapsed() >= warn_interval {
                                             warn!(target: "polygon_sink", dropped = drops_since_warn, interval_secs = warn_interval.as_secs(), "zmq_backpressure");
-                                            drops_since_warn = 0; last_warn = Instant::now();
+                                            drops_since_warn = 0;
+                                            last_warn = Instant::now();
                                         }
                                     } else {
                                         error!(target: "polygon_sink", error = %e, "zmq_send_error");

--- a/src/sink_zmq.rs
+++ b/src/sink_zmq.rs
@@ -1,0 +1,122 @@
+#[cfg(feature = "zmq-sink")]
+use {
+    zmq::{Context, Socket, SocketType, DONTWAIT},
+    serde_json::to_vec,
+    tokio::sync::mpsc::Receiver,
+    tokio::sync::Notify,
+    tracing::{error, info, warn},
+    std::sync::Arc,
+    std::time::{Duration, Instant},
+    crate::metrics::Metrics,
+    crate::ndjson::NdjsonEvent,
+};
+
+#[cfg(feature = "zmq-sink")]
+fn make_socket(ctx: &Context, endpoint: &str, bind: bool, snd_hwm: Option<i32>) -> Result<Socket, Box<dyn std::error::Error>> {
+    let sock = ctx.socket(SocketType::PUB)?;
+    if let Some(hwm) = snd_hwm { sock.set_sndhwm(hwm)?; }
+    if bind { sock.bind(endpoint)?; } else { sock.connect(endpoint)?; }
+    Ok(sock)
+}
+
+#[cfg(feature = "zmq-sink")]
+pub fn spawn_zmq_publisher(
+    mut rx: Receiver<NdjsonEvent>,
+    endpoint: String,
+    bind: bool,
+    snd_hwm: Option<i32>,
+    topic_prefix: String,
+    warn_interval: Duration,
+    metrics: Metrics,
+    notify_shutdown: Arc<Notify>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let ctx = match Context::new() {
+            c @ _ => c,
+        };
+        let mut last_warn = Instant::now() - warn_interval;
+        let mut drops_since_warn: u64 = 0;
+
+        let socket = match make_socket(&ctx, &endpoint, bind, snd_hwm) {
+            Ok(s) => {
+                info!(target: "polygon_sink", mode = "zmq", endpoint = %endpoint, bind = bind, "zmq_ready");
+                s
+            }
+            Err(e) => {
+                error!(target: "polygon_sink", error = %e, endpoint = %endpoint, bind = bind, "zmq_socket_error");
+                // Drain until shutdown so we don't stall tasks
+                loop {
+                    tokio::select! {
+                        _ = notify_shutdown.notified() => break,
+                        _ = rx.recv() => {}
+                    }
+                }
+                return;
+            }
+        };
+
+        // Main pump loop
+        loop {
+            tokio::select! {
+                _ = notify_shutdown.notified() => {
+                    info!(target: "polygon_sink", "zmq_shutdown");
+                    break;
+                }
+                maybe = rx.recv() => {
+                    match maybe {
+                        Some(ev) => {
+                            // Multipart: [topic, payload]
+                            let topic = if ev.symbol.is_empty() {
+                                format!("{}{}", topic_prefix, ev.r#type)
+                            } else {
+                                format!("{}{}:{}", topic_prefix, ev.r#type, ev.symbol)
+                            };
+                            let payload = match to_vec(&ev) { Ok(mut v) => { v.push(b'\n'); v }, Err(_) => { continue; } };
+                            // Non-blocking send; drop on EAGAIN
+                            match socket.send_multipart(&[topic.as_bytes(), &payload], DONTWAIT) {
+                                Ok(()) => { metrics.inc_zmq_sent(); }
+                                Err(e) => {
+                                    // Drop on backpressure
+                                    let again = e
+                                        .as_errno()
+                                        .map(|eno| eno == zmq::errno::EAGAIN)
+                                        .unwrap_or(false);
+                                    if again {
+                                        drops_since_warn = drops_since_warn.saturating_add(1);
+                                        metrics.inc_zmq_drop();
+                                        if last_warn.elapsed() >= warn_interval {
+                                            warn!(target: "polygon_sink", dropped = drops_since_warn, interval_secs = warn_interval.as_secs(), "zmq_backpressure");
+                                            drops_since_warn = 0; last_warn = Instant::now();
+                                        }
+                                    } else {
+                                        error!(target: "polygon_sink", error = %e, "zmq_send_error");
+                                    }
+                                }
+                            }
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+    })
+}
+
+// Stubs when the feature is disabled to keep call sites simple.
+#[cfg(not(feature = "zmq-sink"))]
+#[allow(unused_variables)]
+pub fn spawn_zmq_publisher(
+    rx: tokio::sync::mpsc::Receiver<crate::ndjson::NdjsonEvent>,
+    endpoint: String,
+    bind: bool,
+    snd_hwm: Option<i32>,
+    topic_prefix: String,
+    warn_interval: std::time::Duration,
+    metrics: crate::metrics::Metrics,
+    notify_shutdown: std::sync::Arc<tokio::sync::Notify>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let _ = (rx, endpoint, bind, snd_hwm, topic_prefix, warn_interval, metrics, notify_shutdown);
+        tracing::error!(target: "polygon_sink", "zmq feature not enabled; rebuild with --features zmq-sink");
+    })
+}

--- a/src/sink_zmq.rs
+++ b/src/sink_zmq.rs
@@ -95,7 +95,10 @@ pub fn spawn_zmq_publisher(
                             topic_buf.reserve(need);
                             topic_buf.extend_from_slice(topic_prefix.as_bytes());
                             topic_buf.extend_from_slice(ev.r#type.as_bytes());
-                            if !ev.symbol.is_empty() { topic_buf.push(b':'); topic_buf.extend_from_slice(ev.symbol.as_bytes()); }
+                            if !ev.symbol.is_empty() {
+                                topic_buf.push(b':');
+                                topic_buf.extend_from_slice(ev.symbol.as_bytes());
+                            }
                             let payload = match to_vec(&ev) {
                                 Ok(mut v) => { v.push(b'\n'); v },
                                 Err(e) => {

--- a/src/sink_zmq.rs
+++ b/src/sink_zmq.rs
@@ -31,9 +31,7 @@ pub fn spawn_zmq_publisher(
     notify_shutdown: Arc<Notify>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let ctx = match Context::new() {
-            c @ _ => c,
-        };
+        let ctx = Context::new();
         let mut last_warn = Instant::now() - warn_interval;
         let mut drops_since_warn: u64 = 0;
 

--- a/src/sink_zmq.rs
+++ b/src/sink_zmq.rs
@@ -92,7 +92,9 @@ pub fn spawn_zmq_publisher(
                             // Build topic directly as bytes to avoid intermediate String
                             topic_buf.clear();
                             let need = topic_prefix.len() + ev.r#type.len() + if ev.symbol.is_empty() { 0 } else { 1 + ev.symbol.len() };
-                            topic_buf.reserve(need);
+                            if topic_buf.capacity() < need {
+                                topic_buf.reserve(need - topic_buf.capacity());
+                            }
                             topic_buf.extend_from_slice(topic_prefix.as_bytes());
                             topic_buf.extend_from_slice(ev.r#type.as_bytes());
                             if !ev.symbol.is_empty() {

--- a/src/sink_zmq.rs
+++ b/src/sink_zmq.rs
@@ -92,7 +92,7 @@ pub fn spawn_zmq_publisher(
                             // Build topic directly as bytes to avoid intermediate String
                             topic_buf.clear();
                             let need = topic_prefix.len() + ev.r#type.len() + if ev.symbol.is_empty() { 0 } else { 1 + ev.symbol.len() };
-                            topic_buf.reserve(need.saturating_sub(topic_buf.capacity()));
+                            topic_buf.reserve(need);
                             topic_buf.extend_from_slice(topic_prefix.as_bytes());
                             topic_buf.extend_from_slice(ev.r#type.as_bytes());
                             if !ev.symbol.is_empty() { topic_buf.push(b':'); topic_buf.extend_from_slice(ev.symbol.as_bytes()); }

--- a/src/sink_zmq.rs
+++ b/src/sink_zmq.rs
@@ -90,7 +90,12 @@ pub fn spawn_zmq_publisher(
                             // Multipart: [topic, payload]
                             // Build topic directly as bytes to avoid intermediate String
                             topic_buf.clear();
-                            let need = topic_prefix.len() + ev.r#type.len() + if ev.symbol.is_empty() { 0 } else { 1 + ev.symbol.len() };
+                            let symbol_overhead = if ev.symbol.is_empty() {
+                                0
+                            } else {
+                                1 + ev.symbol.len() // ':' separator + symbol
+                            };
+                            let need = topic_prefix.len() + ev.r#type.len() + symbol_overhead;
                             if topic_buf.capacity() < need {
                                 topic_buf.reserve(need - topic_buf.capacity());
                             }


### PR DESCRIPTION
Title
  feat(zmq): add subscriber example, dedicated metrics, and Docker feature build

  Summary

  - Add simple ZMQ subscriber examples (Rust + Python) to validate PUB sink.
  - Extend metrics with dedicated ZMQ counters; stop reusing NDJSON drop counters.
  - Add Docker build arg to optionally build ZMQ-enabled image and publish variant tags via CI.

  Motivation

  - Make it easy to consume the ZMQ PUB stream.
  - Provide accurate ZMQ telemetry (sent vs. dropped) without conflating NDJSON metrics.
  - Support containerized deployments that need ZMQ without bloating default images.

  Changes

  - ZMQ examples
      - Rust example updated and gated behind feature: examples/zmq_sub.rs
      - New Python example: examples/zmq_sub.py
  - ZMQ sink and metrics
      - Use ZMQ-specific counters on backpressure in processing path: src/main.rs:385
      - ZMQ sender uses non-blocking EAGAIN detection and increments sent/drops: src/sink_zmq.rs:63
  - Docker
      - Add build arg to enable ZMQ and install libzmq at build/runtime: Dockerfile
      - CI workflow to build/push both default and ZMQ images to GHCR: .github/workflows/docker.yml
  - Docs
      - README updates for examples, metrics, and Docker tags: README.md

  Usage

  - Build/run (host)
      - ZMQ feature: cargo build --release --features zmq-sink
      - Run PUB sink: SINK=zmq ZMQ_ENDPOINT=tcp://127.0.0.1:5556 RUST_LOG=warn cargo run --release --features zmq-sink
      - Rust SUB: cargo run --release --features zmq-sink --example zmq_sub
      - Python SUB: pip install pyzmq && ZMQ_SUB_ENDPOINT=tcp://127.0.0.1:5556 python3 examples/zmq_sub.py
  - Docker
      - Build ZMQ image: docker build --build-arg ENABLE_ZMQ_SINK=1 -t polygon-rs:zmq .
      - Run PUB (host net): docker run --rm --network host -e POLYGON_API_KEY=$POLYGON_API_KEY -e SINK=zmq -e ZMQ_BIND=true -e ZMQ_ENDPOINT=tcp://0.0.0.0:5556 polygon-rs:zmq
      - Or with port mapping: docker run --rm -p 5556:5556 -e POLYGON_API_KEY=$POLYGON_API_KEY -e SINK=zmq -e ZMQ_BIND=true -e ZMQ_ENDPOINT=tcp://0.0.0.0:5556 polygon-rs:zmq
      - CI tags (GHCR): ghcr.io/OWNER/REPO:latest (default), ghcr.io/OWNER/REPO:zmq, ghcr.io/OWNER/REPO:latest-zmq

  Metrics Highlights

  - ZMQ-specific
      - polygon_zmq_sent_total — successfully published ZMQ messages
      - polygon_zmq_drops_total — messages dropped on ZMQ backpressure
  - NDJSON-specific (unchanged)
      - polygon_ndjson_written_total, polygon_ndjson_drops_total
  - Health endpoints
      - curl -s http://127.0.0.1:9898/metrics | rg polygon_zmq_
      - curl -s http://127.0.0.1:9898/health and /ready

  Testing Notes

  - cargo test --release passes.
  - cargo build --release --features zmq-sink passes.
  - Docker ZMQ build works: docker build --build-arg ENABLE_ZMQ_SINK=1 -t polygon-rs:zmq .

  Backward Compatibility

  - Default behavior unchanged; ZMQ code is behind the zmq-sink feature and Docker build arg.

  Files Touched

  - src/main.rs:385 — ZMQ-aware backpressure metrics path
  - src/sink_zmq.rs:63 — ZMQ send, EAGAIN handling, metrics
  - examples/zmq_sub.rs:1 — gated Rust SUB example
  - examples/zmq_sub.py:1 — Python SUB example
  - Dockerfile:1 — optional ZMQ build support
  - .github/workflows/docker.yml:1 — GHCR image builds (default + ZMQ)
  - README.md:130 — usage, metrics, and CI tag updates
