### PR TITLE
Add NNG sink for high-performance message publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,3 +60,16 @@ jobs:
             ghcr.io/${{ github.repository }}:latest-zmq
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Build and push (nng)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            ENABLE_NNG_SINK=1
+          tags: |
+            ghcr.io/${{ github.repository }}:nng
+            ghcr.io/${{ github.repository }}:latest-nng
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,13 @@ smallvec = "1.15"
 default = []
 # Enable ZeroMQ sink support (requires libzmq on the system)
 zmq-sink = ["zmq"]
+# Enable NNG sink support (requires libnng on the system)
+nng-sink = ["nng"]
 
 [dependencies.zmq]
 version = "0.10"
+optional = true
+
+[dependencies.nng]
+version = "1.0"
 optional = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ ENV CARGO_PROFILE_RELEASE_LTO=true \
 ARG ENABLE_ZMQ_SINK=0
 ARG ENABLE_NNG_SINK=0
 RUN apt-get update && \
-    if [ "$ENABLE_ZMQ_SINK" = "1" ]; then apt-get install -y --no-install-recommends libzmq3-dev cmake; fi && \
-    if [ "$ENABLE_NNG_SINK" = "1" ]; then apt-get install -y --no-install-recommends libnng-dev cmake; fi && \
+    if [ "$ENABLE_ZMQ_SINK" = "1" ] || [ "$ENABLE_NNG_SINK" = "1" ]; then apt-get install -y --no-install-recommends cmake; fi && \
+    if [ "$ENABLE_ZMQ_SINK" = "1" ]; then apt-get install -y --no-install-recommends libzmq3-dev; fi && \
+    if [ "$ENABLE_NNG_SINK" = "1" ]; then apt-get install -y --no-install-recommends libnng-dev; fi && \
     rm -rf /var/lib/apt/lists/* && \
     FEATURES=""; \
     if [ "$ENABLE_ZMQ_SINK" = "1" ] && [ "$ENABLE_NNG_SINK" = "1" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,21 @@ ENV CARGO_PROFILE_RELEASE_LTO=true \
     CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
     CARGO_PROFILE_RELEASE_STRIP=symbols
 ARG ENABLE_ZMQ_SINK=0
-RUN if [ "$ENABLE_ZMQ_SINK" = "1" ]; then \
-      apt-get update && apt-get install -y --no-install-recommends libzmq3-dev && \
-      cargo build --release --features zmq-sink; \
+ARG ENABLE_NNG_SINK=0
+RUN apt-get update && \
+    if [ "$ENABLE_ZMQ_SINK" = "1" ]; then apt-get install -y --no-install-recommends libzmq3-dev cmake; fi && \
+    if [ "$ENABLE_NNG_SINK" = "1" ]; then apt-get install -y --no-install-recommends libnng-dev cmake; fi && \
+    rm -rf /var/lib/apt/lists/* && \
+    FEATURES=""; \
+    if [ "$ENABLE_ZMQ_SINK" = "1" ] && [ "$ENABLE_NNG_SINK" = "1" ]; then \
+      FEATURES="zmq-sink,nng-sink"; \
+    elif [ "$ENABLE_ZMQ_SINK" = "1" ]; then \
+      FEATURES="zmq-sink"; \
+    elif [ "$ENABLE_NNG_SINK" = "1" ]; then \
+      FEATURES="nng-sink"; \
+    fi; \
+    if [ -n "$FEATURES" ]; then \
+      cargo build --release --features "$FEATURES"; \
     else \
       cargo build --release; \
     fi
@@ -21,10 +33,12 @@ RUN if [ "$ENABLE_ZMQ_SINK" = "1" ]; then \
 FROM debian:bookworm-slim AS runtime
 # Install required runtime dependencies (OpenSSL runtime only)
 ARG ENABLE_ZMQ_SINK=0
+ARG ENABLE_NNG_SINK=0
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3 \
     ca-certificates \
     $(if [ "$ENABLE_ZMQ_SINK" = "1" ]; then echo libzmq5; fi) \
+    $(if [ "$ENABLE_NNG_SINK" = "1" ]; then echo libnng1; fi) \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the compiled binary

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,14 @@ pub struct Config {
     pub zmq_warn_interval: Duration,
     pub zmq_snd_hwm: Option<i32>,
     pub zmq_topic_prefix: String,
+
+    // NNG sink configuration
+    pub nng_endpoint: String,
+    pub nng_bind: bool,
+    pub nng_channel_cap: usize,
+    pub nng_warn_interval: Duration,
+    pub nng_snd_buf_size: Option<usize>,
+    pub nng_topic_prefix: String,
 }
 
 impl Config {
@@ -193,6 +201,24 @@ impl Config {
                 .ok()
                 .and_then(|v| v.parse::<i32>().ok()),
             zmq_topic_prefix: env::var("ZMQ_TOPIC_PREFIX").unwrap_or_else(|_| "".to_string()),
+
+            // NNG sink
+            nng_endpoint: env::var("NNG_ENDPOINT")
+                .unwrap_or_else(|_| "tcp://127.0.0.1:5557".to_string()),
+            nng_bind: parse_bool(env::var("NNG_BIND").ok().as_deref()),
+            nng_channel_cap: env::var("NNG_CHANNEL_CAP")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(4096),
+            nng_warn_interval: env::var("NNG_WARN_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(Duration::from_secs)
+                .unwrap_or_else(|| Duration::from_secs(5)),
+            nng_snd_buf_size: env::var("NNG_SND_BUF_SIZE")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok()),
+            nng_topic_prefix: env::var("NNG_TOPIC_PREFIX").unwrap_or_else(|_| "".to_string()),
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod metrics;
 mod model;
 mod ndjson;
 mod sink_zmq;
+mod sink_nng;
 
 // env-only helpers are defined in config.rs
 
@@ -211,6 +212,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             (Some(tx_ev), None, None)
+        } else if sink_kind == "nng" {
+            let (tx_ev, rx_ev) = mpsc::channel::<NdjsonEvent>(cfg.nng_channel_cap);
+            let (init_tx, init_rx) = tokio::sync::oneshot::channel();
+            let _handle = sink_nng::spawn_nng_publisher(
+                rx_ev,
+                cfg.nng_endpoint.clone(),
+                cfg.nng_bind,
+                cfg.nng_snd_buf_size,
+                cfg.nng_topic_prefix.clone(),
+                cfg.nng_warn_interval,
+                metrics.clone(),
+                notify_shutdown.clone(),
+                Some(init_tx),
+            );
+            match timeout(Duration::from_secs(2), init_rx).await {
+                Ok(Ok(true)) => { /* ok */ }
+                Ok(Ok(false)) => {
+                    warn!(target: "polygon_sink", "nng_init_failed");
+                }
+                Ok(Err(_)) => {
+                    warn!(target: "polygon_sink", "nng_init_channel_closed");
+                }
+                Err(_) => {
+                    warn!(target: "polygon_sink", "nng_init_timeout");
+                }
+            }
+            (Some(tx_ev), None, None)
         } else {
             (None, None, None)
         };
@@ -230,10 +258,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ndjson_quotes_tx_opt.as_ref().map(|tx| tx.clone()),
         if sink_kind == "zmq" {
             cfg.zmq_warn_interval
+        } else if sink_kind == "nng" {
+            cfg.nng_warn_interval
         } else {
             cfg.ndjson_warn_interval
         },
-        sink_kind == "zmq",
+        if sink_kind == "zmq" {
+            SinkType::Zmq
+        } else if sink_kind == "nng" {
+            SinkType::Nng
+        } else {
+            SinkType::Ndjson
+        },
         include_patterns,
         cfg.ndjson_sample_quotes.max(1),
         host.clone(),
@@ -458,6 +494,12 @@ where
     Ok(socket)
 }
 
+enum SinkType {
+    Ndjson,
+    Zmq,
+    Nng,
+}
+
 struct NdjsonBp {
     last_warn: Instant,
     dropped_since_warn: u64,
@@ -466,7 +508,7 @@ struct NdjsonBp {
     sample_quotes_n: u64,
     quotes_counter: u64,
     seq_counter: u64,
-    is_zmq_sink: bool,
+    sink_type: SinkType,
 }
 
 impl NdjsonBp {
@@ -474,7 +516,7 @@ impl NdjsonBp {
         warn_interval: Duration,
         include: Option<Vec<IncludePattern>>,
         sample_quotes_n: u64,
-        is_zmq_sink: bool,
+        sink_type: SinkType,
     ) -> Self {
         NdjsonBp {
             last_warn: Instant::now() - warn_interval,
@@ -484,23 +526,29 @@ impl NdjsonBp {
             sample_quotes_n,
             quotes_counter: 0,
             seq_counter: 0,
-            is_zmq_sink,
+            sink_type,
         }
     }
 }
 
 fn record_sink_backpressure(metrics: &Metrics, bp: &mut NdjsonBp) {
-    if bp.is_zmq_sink {
-        metrics.inc_zmq_drop();
-    } else {
-        metrics.inc_ndjson_drop();
+    match bp.sink_type {
+        SinkType::Zmq => metrics.inc_zmq_drop(),
+        SinkType::Nng => metrics.inc_nng_drop(),
+        SinkType::Ndjson => metrics.inc_ndjson_drop(),
     }
     bp.dropped_since_warn = bp.dropped_since_warn.saturating_add(1);
     if bp.last_warn.elapsed() >= bp.warn_interval {
-        if bp.is_zmq_sink {
-            warn!(target: "polygon_sink", dropped = bp.dropped_since_warn, interval_secs = bp.warn_interval.as_secs(), "zmq_backpressure");
-        } else {
-            warn!(target: "polygon_ndjson", dropped = bp.dropped_since_warn, interval_secs = bp.warn_interval.as_secs(), "ndjson_backpressure");
+        match bp.sink_type {
+            SinkType::Zmq => {
+                warn!(target: "polygon_sink", dropped = bp.dropped_since_warn, interval_secs = bp.warn_interval.as_secs(), "zmq_backpressure");
+            }
+            SinkType::Nng => {
+                warn!(target: "polygon_sink", dropped = bp.dropped_since_warn, interval_secs = bp.warn_interval.as_secs(), "nng_backpressure");
+            }
+            SinkType::Ndjson => {
+                warn!(target: "polygon_ndjson", dropped = bp.dropped_since_warn, interval_secs = bp.warn_interval.as_secs(), "ndjson_backpressure");
+            }
         }
         bp.dropped_since_warn = 0;
         bp.last_warn = Instant::now();
@@ -539,7 +587,7 @@ fn spawn_message_processor(
     ndjson_trades_tx: Option<Sender<NdjsonEvent>>,
     ndjson_quotes_tx: Option<Sender<NdjsonEvent>>,
     ndjson_warn_interval: Duration,
-    is_zmq_sink: bool,
+    sink_type: SinkType,
     include_patterns: Option<Vec<IncludePattern>>,
     sample_quotes_n: u64,
     host: Arc<String>,
@@ -550,7 +598,7 @@ fn spawn_message_processor(
             ndjson_warn_interval,
             include_patterns,
             sample_quotes_n,
-            is_zmq_sink,
+            sink_type,
         );
         loop {
             tokio::select! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -494,6 +494,7 @@ where
     Ok(socket)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum SinkType {
     Ndjson,
     Zmq,

--- a/src/sink_nng.rs
+++ b/src/sink_nng.rs
@@ -125,7 +125,7 @@ pub fn spawn_nng_publisher(
                             msg_buf.push(b'\n');
 
                             // Non-blocking send; drop on would-block
-                            let msg = nng::Message::from(msg_buf);
+                            let msg = nng::Message::from(&msg_buf[..]);
                             match socket.send(msg) {
                                 Ok(()) => {
                                     metrics.inc_nng_sent();

--- a/src/sink_nng.rs
+++ b/src/sink_nng.rs
@@ -98,9 +98,7 @@ pub fn spawn_nng_publisher(
                                 1 + ev.symbol.len() // ':' separator + symbol
                             };
                             let need = topic_prefix.len() + ev.r#type.len() + symbol_overhead + 1; // +1 for space separator
-                            if topic_buf.capacity() < need {
-                                topic_buf.reserve(need - topic_buf.capacity());
-                            }
+                            topic_buf.reserve(need);
                             topic_buf.extend_from_slice(topic_prefix.as_bytes());
                             topic_buf.extend_from_slice(ev.r#type.as_bytes());
                             if !ev.symbol.is_empty() {

--- a/src/sink_nng.rs
+++ b/src/sink_nng.rs
@@ -124,7 +124,7 @@ pub fn spawn_nng_publisher(
                             msg_buf.push(b'\n');
 
                             // Non-blocking send; drop on would-block
-                            let msg = nng::Message::from(&msg_buf[..]);
+                            let msg = nng::Message::from(msg_buf);
                             match socket.send(msg) {
                                 Ok(()) => {
                                     metrics.inc_nng_sent();

--- a/src/sink_nng.rs
+++ b/src/sink_nng.rs
@@ -21,7 +21,7 @@ fn make_socket(
     let sock = Socket::new(Protocol::Pub0).map_err(|e| e.to_string())?;
 
     if let Some(buf_size) = snd_buf_size {
-        // Clamp to i32::MAX to prevent overflow (NNG API requires i32)
+        // Convert to i32 as required by NNG API, clamping values above i32::MAX
         // Values larger than 2GB are unrealistic for send buffers anyway
         let size = buf_size.min(i32::MAX as usize) as i32;
         sock.set_opt::<nng::options::SendBufferSize>(size)

--- a/src/sink_nng.rs
+++ b/src/sink_nng.rs
@@ -21,7 +21,8 @@ fn make_socket(
     let sock = Socket::new(Protocol::Pub0).map_err(|e| e.to_string())?;
 
     if let Some(buf_size) = snd_buf_size {
-        sock.set_opt::<nng::options::SendBufferSize>(buf_size as i32)
+        let size = buf_size.min(i32::MAX as usize) as i32;
+        sock.set_opt::<nng::options::SendBufferSize>(size)
             .map_err(|e| e.to_string())?;
     }
 

--- a/src/sink_nng.rs
+++ b/src/sink_nng.rs
@@ -1,0 +1,186 @@
+#[cfg(feature = "nng-sink")]
+use {
+    crate::metrics::Metrics,
+    crate::ndjson::NdjsonEvent,
+    serde_json::to_vec,
+    smallvec::SmallVec,
+    std::sync::Arc,
+    std::time::{Duration, Instant},
+    tokio::sync::mpsc::Receiver,
+    tokio::sync::{oneshot, Notify},
+    tracing::{error, info, warn},
+    nng::{Socket, Protocol},
+};
+
+#[cfg(feature = "nng-sink")]
+fn make_socket(
+    endpoint: &str,
+    bind: bool,
+    snd_buf_size: Option<usize>,
+) -> Result<Socket, String> {
+    let sock = Socket::new(Protocol::Pub0).map_err(|e| e.to_string())?;
+
+    if let Some(buf_size) = snd_buf_size {
+        sock.set_opt::<nng::options::SendBufferSize>(buf_size)
+            .map_err(|e| e.to_string())?;
+    }
+
+    // Set non-blocking mode for sends
+    sock.set_opt::<nng::options::SendTimeout>(Some(Duration::from_millis(0)))
+        .map_err(|e| e.to_string())?;
+
+    if bind {
+        sock.listen(endpoint).map_err(|e| e.to_string())?;
+    } else {
+        sock.dial(endpoint).map_err(|e| e.to_string())?;
+    }
+
+    Ok(sock)
+}
+
+#[cfg(feature = "nng-sink")]
+pub fn spawn_nng_publisher(
+    mut rx: Receiver<NdjsonEvent>,
+    endpoint: String,
+    bind: bool,
+    snd_buf_size: Option<usize>,
+    topic_prefix: String,
+    warn_interval: Duration,
+    metrics: Metrics,
+    notify_shutdown: Arc<Notify>,
+    init_tx: Option<oneshot::Sender<bool>>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut last_warn = Instant::now() - warn_interval;
+        let mut drops_since_warn: u64 = 0;
+
+        let socket = match make_socket(&endpoint, bind, snd_buf_size) {
+            Ok(s) => {
+                info!(target: "polygon_sink", mode = "nng", endpoint = %endpoint, bind = bind, "nng_ready");
+                if let Some(tx) = init_tx {
+                    let _ = tx.send(true);
+                }
+                s
+            }
+            Err(emsg) => {
+                error!(target: "polygon_sink", error = %emsg, endpoint = %endpoint, bind = bind, "nng_socket_error");
+                if let Some(tx) = init_tx {
+                    let _ = tx.send(false);
+                }
+                // Drain until shutdown so we don't stall tasks
+                loop {
+                    tokio::select! {
+                        _ = notify_shutdown.notified() => break,
+                        _ = rx.recv() => {}
+                    }
+                }
+                return;
+            }
+        };
+
+        // Main pump loop
+        // Reuse topic buffer (smallvec) to minimize allocations per send
+        let mut topic_buf: SmallVec<[u8; 64]> = SmallVec::new();
+        loop {
+            tokio::select! {
+                _ = notify_shutdown.notified() => {
+                    info!(target: "polygon_sink", "nng_shutdown");
+                    break;
+                }
+                maybe = rx.recv() => {
+                    match maybe {
+                        Some(ev) => {
+                            // Build topic as prefix for message
+                            topic_buf.clear();
+                            let symbol_overhead = if ev.symbol.is_empty() {
+                                0
+                            } else {
+                                1 + ev.symbol.len() // ':' separator + symbol
+                            };
+                            let need = topic_prefix.len() + ev.r#type.len() + symbol_overhead + 1; // +1 for space separator
+                            if topic_buf.capacity() < need {
+                                topic_buf.reserve(need - topic_buf.capacity());
+                            }
+                            topic_buf.extend_from_slice(topic_prefix.as_bytes());
+                            topic_buf.extend_from_slice(ev.r#type.as_bytes());
+                            if !ev.symbol.is_empty() {
+                                topic_buf.push(b':');
+                                topic_buf.extend_from_slice(ev.symbol.as_bytes());
+                            }
+                            topic_buf.push(b' ');
+
+                            // Serialize payload
+                            let payload_json = match to_vec(&ev) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    metrics.inc_error();
+                                    warn!(target: "polygon_sink", error = %e, "nng_serialize_error");
+                                    continue;
+                                }
+                            };
+
+                            // Combine topic and payload into single message
+                            let mut msg_buf = Vec::with_capacity(topic_buf.len() + payload_json.len() + 1);
+                            msg_buf.extend_from_slice(&topic_buf);
+                            msg_buf.extend_from_slice(&payload_json);
+                            msg_buf.push(b'\n');
+
+                            // Non-blocking send; drop on would-block
+                            match socket.send(&msg_buf) {
+                                Ok(()) => {
+                                    metrics.inc_nng_sent();
+                                }
+                                Err(nng::Error::TryAgain) => {
+                                    // Drop on backpressure (would block)
+                                    drops_since_warn = drops_since_warn.saturating_add(1);
+                                    metrics.inc_nng_drop();
+                                    if last_warn.elapsed() >= warn_interval {
+                                        warn!(target: "polygon_sink", dropped = drops_since_warn, interval_secs = warn_interval.as_secs(), "nng_backpressure");
+                                        drops_since_warn = 0;
+                                        last_warn = Instant::now();
+                                    }
+                                }
+                                Err(e) => {
+                                    error!(target: "polygon_sink", error = %e, "nng_send_error");
+                                }
+                            }
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+    })
+}
+
+// Stubs when the feature is disabled to keep call sites simple.
+#[cfg(not(feature = "nng-sink"))]
+#[allow(unused_variables)]
+pub fn spawn_nng_publisher(
+    rx: tokio::sync::mpsc::Receiver<crate::ndjson::NdjsonEvent>,
+    endpoint: String,
+    bind: bool,
+    snd_buf_size: Option<usize>,
+    topic_prefix: String,
+    warn_interval: std::time::Duration,
+    metrics: crate::metrics::Metrics,
+    notify_shutdown: std::sync::Arc<tokio::sync::Notify>,
+    init_tx: Option<tokio::sync::oneshot::Sender<bool>>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        // Report init failure to caller explicitly
+        if let Some(tx) = init_tx {
+            let _ = tx.send(false);
+        }
+        // Log context (endpoint/bind) for clarity
+        tracing::error!(target: "polygon_sink", endpoint = %endpoint, bind = bind, "nng feature not enabled; rebuild with --features nng-sink");
+        // Gracefully drain until shutdown to avoid backpressure upstream
+        let mut rx = rx;
+        loop {
+            tokio::select! {
+                _ = notify_shutdown.notified() => break,
+                maybe = rx.recv() => { if maybe.is_none() { break; } }
+            }
+        }
+    })
+}

--- a/src/sink_nng.rs
+++ b/src/sink_nng.rs
@@ -21,6 +21,8 @@ fn make_socket(
     let sock = Socket::new(Protocol::Pub0).map_err(|e| e.to_string())?;
 
     if let Some(buf_size) = snd_buf_size {
+        // Clamp to i32::MAX to prevent overflow (NNG API requires i32)
+        // Values larger than 2GB are unrealistic for send buffers anyway
         let size = buf_size.min(i32::MAX as usize) as i32;
         sock.set_opt::<nng::options::SendBufferSize>(size)
             .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Add NNG sink for high-performance message publishing

  Summary

  Adds NNG (Nanomsg-Next-Generation) as a new sink option alongside the existing NDJSON, stdout, and ZMQ sinks. NNG provides a lightweight, high-performance messaging library with a simpler API than ZMQ
  while maintaining similar performance characteristics.

  Motivation

  - Provides an alternative to ZMQ for users who prefer NNG's simpler API and more permissive licensing
  - NNG has fewer system dependencies and is easier to deploy in containerized environments
  - Supports the same pub/sub pattern as ZMQ for topic-based message routing
  - Offers similar performance with lower resource overhead

  Changes

  New Files

  - src/sink_nng.rs - NNG publisher implementation with:
    - Pub/sub socket using nng::Protocol::Pub0
    - Non-blocking sends with backpressure handling
    - Topic-based routing: {topic_prefix}{event_type}:{symbol} {json_payload}\n
    - Configurable send buffer size
    - Feature-gated compilation (nng-sink)

  Modified Files

  - Cargo.toml
    - Added nng = "1.0" as optional dependency
    - Added nng-sink feature flag
  - src/config.rs
    - Added NNG configuration fields mirroring ZMQ config
    - Environment variables: NNG_ENDPOINT, NNG_BIND, NNG_CHANNEL_CAP, NNG_WARN_INTERVAL_SECS, NNG_SND_BUF_SIZE, NNG_TOPIC_PREFIX
    - Default endpoint: tcp://127.0.0.1:5557
  - src/metrics.rs
    - Added nng_drops_total and nng_sent_total counters
    - Added inc_nng_drop() and inc_nng_sent() methods
    - Exported Prometheus metrics: polygon_nng_drops_total, polygon_nng_sent_total
  - src/main.rs
    - Added mod sink_nng
    - Refactored is_zmq_sink: bool → sink_type: SinkType enum (Ndjson, Zmq, Nng)
    - Updated record_sink_backpressure() to handle all sink types
    - Added NNG sink initialization with 2-second timeout check
    - Added sink type detection: SINK=nng activates NNG sink

  Configuration

  Set SINK=nng and configure with environment variables:

  export SINK=nng
  export NNG_ENDPOINT=tcp://0.0.0.0:5557
  export NNG_BIND=true                    # Listen (true) or connect (false)
  export NNG_CHANNEL_CAP=4096             # Internal channel buffer size
  export NNG_SND_BUF_SIZE=65536           # Socket send buffer (optional)
  export NNG_WARN_INTERVAL_SECS=5         # Backpressure warning interval
  export NNG_TOPIC_PREFIX=""              # Topic prefix (e.g., "polygon.")

  Build

  # Build with NNG support
  cargo build --features nng-sink

  # Or build with both ZMQ and NNG
  cargo build --features zmq-sink,nng-sink

  Testing

  - ✅ All existing tests pass
  - ✅ Compiles successfully with and without nng-sink feature
  - ✅ Stub implementation logs error when feature is disabled
  - ✅ Metrics properly track NNG drops and sends

  Message Format

  NNG messages follow the same format as ZMQ:
  {topic_prefix}{event_type}:{symbol} {json_payload}\n

  Example:
  T:ESZ4 {"ingest_ts":1234567890,"type":"T","symbol":"ESZ4",...}\n

  Backward Compatibility

  - No breaking changes to existing sinks (NDJSON, stdout, ZMQ)
  - Feature-gated - only compiles when --features nng-sink is specified
  - Existing configurations continue to work unchanged